### PR TITLE
mrc-1533 add api service class

### DIFF
--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -7,7 +7,7 @@ import {RootMutation} from "./mutations";
 
 declare var appUrl: string;
 
-export interface ResponseWithType<T> extends Response {
+export interface ResponseWithType<T> extends ResponseSuccess {
     data: T
 }
 
@@ -25,8 +25,6 @@ export interface API<S, E> {
     postAndReturn<T>(url: string, data: any): Promise<void | ResponseWithType<T>>
 
     get<T>(url: string): Promise<void | ResponseWithType<T>>
-
-    delete(url: string): Promise<void | true>
 }
 
 export class APIService<S extends string, E extends string> implements API<S, E> {

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -1,0 +1,165 @@
+import axios, {AxiosError, AxiosResponse} from "axios";
+import {ActionContext, Commit} from "vuex";
+import {freezer, isMINTResponseFailure} from "./utils";
+import {RootState} from "./store";
+import {ResponseSuccess, ResponseFailure} from "./generated";
+import {RootMutation} from "./mutations";
+
+declare var appUrl: string;
+
+export interface ResponseWithType<T> extends Response {
+    data: T
+}
+
+export interface APIError {
+    error: string;
+    detail: string | null;
+}
+
+export interface API<S, E> {
+
+    withError: (type: E) => API<S, E>
+    withSuccess: (type: S) => API<S, E>
+    ignoreErrors: () => API<S, E>
+
+    postAndReturn<T>(url: string, data: any): Promise<void | ResponseWithType<T>>
+
+    get<T>(url: string): Promise<void | ResponseWithType<T>>
+
+    delete(url: string): Promise<void | true>
+}
+
+export class APIService<S extends string, E extends string> implements API<S, E> {
+
+    private readonly _commit: Commit;
+    private readonly _headers: any;
+
+    constructor(context: ActionContext<RootState, RootState>) {
+        this._commit = context.commit;
+    }
+
+    // appUrl will be set as a jest global during testing
+    private readonly _baseUrl = typeof appUrl !== "undefined" ? appUrl : "";
+
+    private _buildFullUrl = (url: string) => {
+        return this._baseUrl + url
+    };
+
+    private _ignoreErrors: Boolean = false;
+    private _freezeResponse: Boolean = false;
+
+    static getFirstErrorFromFailure = (failure: ResponseFailure) => {
+        if (failure.errors.length == 0) {
+            return APIService
+                .createError("API response failed but did not contain any error information. Please contact support.");
+        }
+        return failure.errors[0];
+    };
+
+    static createError(detail: string) {
+        return {
+            error: "MALFORMED_RESPONSE",
+            detail: detail
+        }
+    }
+
+    private _onError: ((failure: ResponseFailure) => void) | null = null;
+
+    private _onSuccess: ((success: ResponseSuccess) => void) | null = null;
+
+    freezeResponse = () => {
+        this._freezeResponse = true;
+        return this;
+    };
+
+    withError = (type: E) => {
+        this._onError = (failure: ResponseFailure) => {
+            this._commit(type, APIService.getFirstErrorFromFailure(failure));
+        };
+        return this
+    };
+
+    ignoreErrors = () => {
+        this._ignoreErrors = true;
+        return this;
+    };
+
+    withSuccess = (type: S) => {
+        this._onSuccess = (data: any) => {
+            const finalData = this._freezeResponse ? freezer.deepFreeze(data) : data;
+            this._commit(type, finalData);
+        };
+        return this;
+    };
+
+    private _handleAxiosResponse(promise: Promise<AxiosResponse>) {
+        return promise.then((axiosResponse: AxiosResponse) => {
+            const success = axiosResponse && axiosResponse.data;
+            const data = success.data;
+            if (this._onSuccess) {
+                this._onSuccess(data);
+            }
+            return axiosResponse.data;
+        }).catch((e: AxiosError) => {
+            return this._handleError(e)
+        });
+    }
+
+    private _handleError = (e: AxiosError) => {
+        console.log(e.response && e.response.data || e);
+        if (this._ignoreErrors) {
+            return
+        }
+
+        let failure = e.response && e.response.data;
+
+        if (!isMINTResponseFailure(failure)) {
+            this._commitError(APIService.createError("Could not parse API response. Please contact support."));
+        } else if (this._onError) {
+            this._onError(failure);
+        } else {
+            this._commitError(APIService.getFirstErrorFromFailure(failure));
+        }
+    };
+
+    private _commitError = (error: APIError) => {
+        this._commit(RootMutation.AddError, error);
+    };
+
+    private _verifyHandlers(url: string) {
+        if (this._onError == null && !this._ignoreErrors) {
+            console.warn(`No error handler registered for request ${url}.`)
+        }
+        if (this._onSuccess == null) {
+            console.warn(`No success handler registered for request ${url}.`)
+        }
+    }
+
+    async get<T>(url: string): Promise<void | ResponseWithType<T>> {
+        this._verifyHandlers(url);
+        const fullUrl = this._buildFullUrl(url);
+        return this._handleAxiosResponse(axios.get(fullUrl, {headers: this._headers}));
+    }
+
+    async postAndReturn<T>(url: string, data?: any): Promise<void | ResponseWithType<T>> {
+        this._verifyHandlers(url);
+        const fullUrl = this._buildFullUrl(url);
+
+        // this allows us to pass data of type FormData in both the browser and
+        // in node for testing, using the "form-data" package in the latter case
+        const headers = data && typeof data.getHeaders == "function" ?
+            {...this._headers, ...data.getHeaders()}
+            : this._headers;
+
+        return this._handleAxiosResponse(axios.post(fullUrl, data, {headers}));
+    }
+
+    async delete(url: string) {
+        const fullUrl = this._buildFullUrl(url);
+        return this._handleAxiosResponse(axios.delete(fullUrl));
+    }
+
+}
+
+export const api =
+    <S extends string, E extends string>(context: ActionContext<RootState, RootState>) => new APIService<S, E>(context);

--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -154,11 +154,6 @@ export class APIService<S extends string, E extends string> implements API<S, E>
         return this._handleAxiosResponse(axios.post(fullUrl, data, {headers}));
     }
 
-    async delete(url: string) {
-        const fullUrl = this._buildFullUrl(url);
-        return this._handleAxiosResponse(axios.delete(fullUrl));
-    }
-
 }
 
 export const api =

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -1,10 +1,12 @@
 import {MutationTree} from "vuex";
 import {RootState} from "./store";
 import {Project} from "./models/project";
+import {APIError} from "./apiService";
 
 export enum RootMutation {
     AddProject = "AddProject",
-    SetCurrentRegion = "SetCurrentRegion"
+    SetCurrentRegion = "SetCurrentRegion",
+    AddError = "AddError"
 }
 
 export const mutations: MutationTree<RootState> = {
@@ -16,5 +18,9 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.SetCurrentRegion](state: RootState, payload: string) {
         state.currentProject && state.currentProject.setCurrentRegion(payload);
+    },
+
+    [RootMutation.AddError](state: RootState, payload: APIError) {
+        state.errors.push(payload)
     }
 }

--- a/src/app/static/src/app/store.ts
+++ b/src/app/static/src/app/store.ts
@@ -4,10 +4,12 @@ import {MutationPayload, Store, StoreOptions} from "vuex";
 
 import {mutations} from "./mutations";
 import {Project} from "./models/project";
+import {APIError} from "./apiService";
 
 export interface RootState {
     projects: Project[]
     currentProject: Project | null
+    errors: APIError[]
 }
 
 const logger = (store: Store<RootState>) => {
@@ -19,7 +21,8 @@ const logger = (store: Store<RootState>) => {
 const storeOptions: StoreOptions<RootState> = {
     state: {
         projects: [],
-        currentProject: null
+        currentProject: null,
+        errors: []
     },
     mutations,
     plugins: [logger]

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -1,5 +1,35 @@
 import {mapMutations, MutationMethod} from "vuex";
+import {ResponseFailure, ResponseSuccess} from "./generated";
 
 export const mapMutationByName = (name: string): MutationMethod => {
     return mapMutations([name])[name]
+};
+
+function isMINTError(object: any): object is Error {
+    return typeof object.error == "string"
+        && object.details == undefined || typeof object.details == "string"
+}
+
+export function isMINTResponseFailure(object: any): object is ResponseFailure {
+    return object && object.status == "failure"
+        && (Array.isArray(object.errors))
+        && object.errors.every((e: any) => isMINTError(e))
+}
+
+export const freezer = {
+
+    deepFreeze: (data: any): any => {
+        if (Array.isArray(data)) {
+            return Object.freeze(data.map(d => freezer.deepFreeze(d)))
+        }
+        if (data != null && typeof data === "object") {
+            for (let prop in data) {
+                if (data.hasOwnProperty(prop)) {
+                    data[prop] = freezer.deepFreeze(data[prop])
+                }
+            }
+            return Object.freeze(data);
+        }
+        return data;
+    }
 };

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -1,0 +1,267 @@
+import {api} from "../app/apiService";
+import {mockAxios, mockError, mockFailure, mockRootState, mockSuccess} from "./mocks";
+import {freezer} from '../app/utils';
+import {RootMutation} from "../app/mutations";
+
+const rootState = mockRootState();
+
+describe("ApiService", () => {
+
+    beforeEach(() => {
+        console.log = jest.fn();
+        console.warn = jest.fn();
+        mockAxios.reset();
+    });
+
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
+        (console.warn as jest.Mock).mockClear();
+    });
+
+    it("console logs error", async () => {
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure("some error message"));
+
+        try {
+            await api({commit: jest.fn(), rootState} as any)
+                .get("/baseline/")
+        } catch (e) {
+
+        }
+        expect((console.warn as jest.Mock).mock.calls[0][0])
+            .toBe("No error handler registered for request /baseline/.");
+        expect((console.log as jest.Mock).mock.calls[0][0].errors[0].detail)
+            .toBe("some error message");
+    });
+
+    it("commits the the first error message by default", async () => {
+
+        mockAxios.onGet(`/unusual/`)
+            .reply(500, mockFailure("some error message"));
+
+        const commit = jest.fn();
+
+        await api({commit, rootState} as any)
+            .get("/unusual/");
+
+        expect((console.warn as jest.Mock).mock.calls[0][0])
+            .toBe("No error handler registered for request /unusual/.");
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddError);
+        expect(commit.mock.calls[0][1]).toStrictEqual(mockError("some error message"));
+    });
+
+    it("if no first error message, commits a default error message to errors module by default", async () => {
+
+        const failure = {
+            data: {},
+            status: "failure",
+            errors: []
+        };
+        mockAxios.onGet(`/unusual/`)
+            .reply(500, failure);
+
+        const commit = jest.fn();
+
+        await api({commit, rootState} as any)
+            .get("/unusual/");
+
+        expect((console.warn as jest.Mock).mock.calls[0][0])
+            .toBe("No error handler registered for request /unusual/.");
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddError);
+        expect(commit.mock.calls[0][1]).toStrictEqual({
+            error: "MALFORMED_RESPONSE",
+            detail: "API response failed but did not contain any error information. Please contact support.",
+        });
+    });
+
+    it("commits the first error with the specified type if well formatted", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure("some error message"));
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+
+        const commit = (type: string, payload: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+
+        await api({commit, rootState} as any)
+            .withError("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(committedPayload).toStrictEqual(mockError("some error message"));
+    });
+
+    it("commits the error type if the error detail is missing", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure(null as any));
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+
+        const commit = (type: string, payload: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+
+        await api({commit, rootState} as any)
+            .withError("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(committedPayload).toStrictEqual({error: "OTHER_ERROR", detail: null});
+    });
+
+    it("commits the success response with the specified type", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess(true));
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+        const commit = (type: string, payload: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+
+        await api({commit, rootState} as any)
+            .withSuccess("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(committedPayload).toBe(true);
+    });
+
+    it("returns the response object", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess("TEST"));
+
+        const commit = jest.fn();
+        const response = await api({commit, rootState} as any)
+            .withSuccess("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(response).toStrictEqual({data: "TEST", errors: null, status: "success"});
+    });
+
+    it("deep freezes the response object if requested", async () => {
+
+        const fakeData = {name: "d1"};
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess(fakeData));
+
+        const spy = jest.spyOn(freezer, "deepFreeze");
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+        const commit = (type: string, payload: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+        await api({commit, rootState} as any)
+            .freezeResponse()
+            .withSuccess("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(Object.isFrozen(committedPayload)).toBe(true);
+        expect(spy.mock.calls[0][0]).toStrictEqual(fakeData);
+    });
+
+    it("does not deep freeze the response object if not requested", async () => {
+
+        const fakeData = {name: "d1"};
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess(fakeData));
+
+        const spy = jest.spyOn(freezer, "deepFreeze");
+
+        let committedType: any = false;
+        let committedPayload: any = false;
+        const commit = (type: string, payload: any) => {
+            committedType = type;
+            committedPayload = payload;
+        };
+        await api({commit, rootState} as any)
+            .withSuccess("TEST_TYPE")
+            .get("/baseline/");
+
+        expect(committedType).toBe("TEST_TYPE");
+        expect(Object.isFrozen(committedPayload)).toBe(false);
+        expect(spy.mock.calls[0][0]).toStrictEqual(fakeData);
+    });
+
+    it("throws error if API response is null", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500);
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("throws error if API response status is missing", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, {data: {}, errors: []});
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("throws error if API response errors are missing", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, {data: {}, status: "failure"});
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("does nothing on error if ignoreErrors is true", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure("some error message"));
+
+        await api({commit: jest.fn(), rootState} as any)
+            .withSuccess("whatever")
+            .ignoreErrors()
+            .get("/baseline/");
+
+        expect((console.warn as jest.Mock).mock.calls.length).toBe(0);
+    });
+
+    it("warns if error and success handlers are not set", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(200, mockSuccess(true));
+
+        await api({commit: jest.fn(), rootState} as any)
+            .get("/baseline/");
+
+        const warnings = (console.warn as jest.Mock).mock.calls;
+
+        expect(warnings[0][0]).toBe("No error handler registered for request /baseline/.");
+        expect(warnings[1][0]).toBe("No success handler registered for request /baseline/.");
+    });
+
+    async function expectCouldNotParseAPIResponseError() {
+        const commit = jest.fn();
+        await api({commit, rootState} as any)
+            .get("/baseline/");
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddError);
+        expect(commit.mock.calls[0][1]).toStrictEqual({
+            error: "MALFORMED_RESPONSE",
+            detail: "Could not parse API response. Please contact support."
+        });
+    }
+
+});

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -251,6 +251,19 @@ describe("ApiService", () => {
         expect(warnings[1][0]).toBe("No success handler registered for request /baseline/.");
     });
 
+    it("returns the response object from a POST", async () => {
+
+        mockAxios.onPost(`/baseline/`)
+            .reply(200, mockSuccess("TEST"));
+
+        const commit = jest.fn();
+        const response = await api({commit, rootState} as any)
+            .withSuccess("TEST_TYPE")
+            .postAndReturn("/baseline/", {});
+
+        expect(response).toStrictEqual({data: "TEST", errors: null, status: "success"});
+    });
+
     async function expectCouldNotParseAPIResponseError() {
         const commit = jest.fn();
         await api({commit, rootState} as any)

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -1,9 +1,36 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import {RootState} from "../app/store";
+import {ResponseFailure, ResponseSuccess} from "../app/generated";
+import {APIError} from "../app/apiService";
 
 export function mockRootState(state: Partial<RootState> = {}): RootState {
     return {
         projects: [],
         currentProject: null,
+        errors: [],
         ...state
     }
 }
+
+export const mockSuccess = (data: any): ResponseSuccess => {
+    return {
+        data,
+        status: "success",
+        errors: null
+    }
+};
+
+export const mockFailure = (errorMessage: string): ResponseFailure => {
+    return {
+        data: null,
+        status: "failure",
+        errors: [mockError(errorMessage)]
+    }
+};
+
+export const mockError = (errorMessage: string): APIError => {
+    return {error: "OTHER_ERROR", detail: errorMessage};
+};
+
+export const mockAxios = new MockAdapter(axios);

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -1,5 +1,5 @@
 import {mutations, RootMutation} from "../../app/mutations";
-import {mockRootState} from "../mocks";
+import {mockError, mockRootState} from "../mocks";
 import {Project} from "../../app/models/project";
 
 describe("mutations", () => {
@@ -27,6 +27,15 @@ describe("mutations", () => {
             name: "South region",
             url: "/projects/my-project/regions/south-region"
         })
+    });
+
+    it("adds error", () => {
+        const state = mockRootState();
+        mutations[RootMutation.AddError](state, mockError("some message detail"));
+
+        expect(state.errors.length).toBe(1);
+        expect(state.errors[0].detail).toBe("some message detail");
+
     });
 
 });

--- a/src/app/static/src/tests/utils.test.ts
+++ b/src/app/static/src/tests/utils.test.ts
@@ -1,0 +1,90 @@
+import {freezer, isMINTResponseFailure} from "../app/utils";
+import {mockError} from "./mocks";
+
+describe("utils", () => {
+    it("deep freezes an object", () => {
+
+        const data = {
+            nothing: null,
+            time: 10,
+            name: "hello",
+            items: [1, null, "three", {label: "l1"}],
+            child: {
+                name: "child",
+                items: [4, null, "five"]
+            }
+        };
+
+        const frozen = freezer.deepFreeze({...data});
+        expect(frozen).toStrictEqual(data);
+        expect(Object.isFrozen(frozen)).toBe(true);
+        expect(Object.isFrozen(frozen.items)).toBe(true);
+        expect(Object.isFrozen(frozen.child)).toBe(true);
+        expect(Object.isFrozen(frozen.child.items)).toBe(true);
+    });
+
+    it("deep freezes an array", () => {
+
+        const data = [{id: 1}, {child: {id: 2}}, 1, "hi"];
+
+        const frozen = freezer.deepFreeze([...data]);
+        expect(frozen).toStrictEqual(data);
+        expect(Object.isFrozen(frozen[0])).toBe(true);
+        expect(Object.isFrozen(frozen[1].child)).toBe(true);
+    });
+
+    describe("isMINTResponseFailure", () => {
+
+        it("is false  if errors are missing", () => {
+            const test = {
+                status: "failure"
+            }
+
+            expect(isMINTResponseFailure(test)).toBe(false);
+        });
+
+        it("is false  if errors are not an array", () => {
+            const test = {
+                errors: {},
+                status: "failure"
+            }
+
+            expect(isMINTResponseFailure(test)).toBe(false);
+        });
+
+        it("is false  if error items are not in correct format", () => {
+            const test = {
+                errors: ["message"],
+                status: "failure"
+            }
+
+            expect(isMINTResponseFailure(test)).toBe(false);
+        });
+
+        it("is false if status is not failure", () => {
+            const test = {
+                errors: [],
+                status: "success"
+            }
+
+            expect(isMINTResponseFailure(test)).toBe(false);
+        });
+
+        it("is true if status is failure and errors are a valid array", () => {
+            const testEmpty = {
+                errors: [],
+                status: "failure"
+            }
+
+            const test = {
+                errors: [mockError("some message")],
+                status: "failure"
+            }
+
+            expect(isMINTResponseFailure(testEmpty)).toBe(true);
+            expect(isMINTResponseFailure(test)).toBe(true);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Prior to actually adding an action to retrieve data, this adds the api service class more or less copied and pasted from hint, slightly modified to remove translations and commit errors directly to the root state. Of course right now nothing happens with those errors, but we can add a global error component in due course.

Contains commits from https://github.com/mrc-ide/mint/pull/11