### PR TITLE
mrc-1533 get prevalence graph data

### DIFF
--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -5,10 +5,8 @@ describe("actions", () => {
 
     it("can get prevalence graph data", async () => {
         const commit = jest.fn();
-        const dispatch = jest.fn();
-        const state = {country: "Malawi"} as any;
 
-        await (actions[RootAction.FetchPrevalenceGraphData] as any)({commit, state, dispatch} as any, {});
+        await (actions[RootAction.FetchPrevalenceGraphData] as any)({commit} as any, {});
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddPrevalenceGraphData);
         const firstRow = commit.mock.calls[0][1][0]


### PR DESCRIPTION
Adds an action and mutation for fetching/committing the prevalence graph data.
~~Contains commits from https://github.com/mrc-ide/mint/pull/12~~