### PR TITLE
mrc-1548 Fetch baseline options from backend, and display in form

### DIFF
--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -3,13 +3,22 @@ import {RootState} from "./store";
 import {api} from "./apiService";
 import {Data, Graph} from "./generated";
 import {RootMutation} from "./mutations";
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 export enum RootAction {
     FetchPrevalenceGraphData = "FetchPrevalenceGraphData",
-    FetchPrevalenceGraphConfig = "FetchPrevalenceGraphConfig"
+    FetchPrevalenceGraphConfig = "FetchPrevalenceGraphConfig",
+    FetchBaselineOptions = "FetchBaselineOptions"
 }
 
 export const actions: ActionTree<RootState, RootState> = {
+
+    async [RootAction.FetchBaselineOptions](context) {
+        await api(context)
+            .withSuccess(RootMutation.AddBaselineOptions)
+            .withError(RootMutation.AddError)
+            .get<DynamicFormMeta>("/baseline/options")
+    },
 
     async [RootAction.FetchPrevalenceGraphData](context) {
         await api(context)
@@ -26,4 +35,4 @@ export const actions: ActionTree<RootState, RootState> = {
             .withError(RootMutation.AddError)
             .get<Graph>("/impact/graph/prevalence/config")
     }
-}
+};

--- a/src/app/static/src/app/components/app.vue
+++ b/src/app/static/src/app/components/app.vue
@@ -25,12 +25,24 @@
 </template>
 <script lang="ts">
     import Vue from "vue"
-    import {mapState} from "vuex";
+    import {mapActions, mapState} from "vuex";
     import dropDown from "./dropDown.vue";
     import {BIconGraphUp} from "bootstrap-vue";
+    import {store} from "../store";
 
-    export default Vue.extend({
+    interface Methods {
+        fetchBaselineOptions: () => void
+    }
+
+    export default Vue.extend<{}, Methods, {}, {}>({
+        store,
         components: {dropDown, BIconGraphUp},
-        computed: mapState(["currentProject"])
+        computed: mapState(["currentProject"]),
+        methods: {
+            ...mapActions({fetchBaselineOptions: "FetchBaselineOptions"})
+        },
+        beforeMount: function () {
+            this.fetchBaselineOptions();
+        }
     })
 </script>

--- a/src/app/static/src/app/components/app.vue
+++ b/src/app/static/src/app/components/app.vue
@@ -29,6 +29,7 @@
     import dropDown from "./dropDown.vue";
     import {BIconGraphUp} from "bootstrap-vue";
     import {store} from "../store";
+    import {RootAction} from "../actions";
 
     interface Methods {
         fetchBaselineOptions: () => void
@@ -39,7 +40,7 @@
         components: {dropDown, BIconGraphUp},
         computed: mapState(["currentProject"]),
         methods: {
-            ...mapActions({fetchBaselineOptions: "FetchBaselineOptions"})
+            ...mapActions({fetchBaselineOptions: RootAction.FetchBaselineOptions})
         },
         beforeMount: function () {
             this.fetchBaselineOptions();

--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
     import Vue from "vue";
     import {DynamicForm, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
-    import {Project} from "../models/project";
+    import {Project, Region} from "../models/project";
     import {mapState} from "vuex";
 
     interface Computed {
@@ -20,14 +20,14 @@
         components: {DynamicForm},
         computed: {
             ...mapState(["currentProject"]),
-          options:  {
-              get() {
-                  return this.currentProject.currentRegion.baselineOptions
-              },
-              set(value: DynamicFormMeta) {
-                  //TODO: update by calling a mutation to set options in the current region
-              }
-          }
+            options:  {
+                get() {
+                    return this.currentProject.currentRegion.baselineOptions
+                },
+                set(value: DynamicFormMeta) {
+                      //TODO: update by calling a mutation to set options in the current region
+                }
+             }
         }
     });
 </script>

--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -8,201 +8,26 @@
 <script lang="ts">
     import Vue from "vue";
     import {DynamicForm, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+    import {Project} from "../models/project";
+    import {mapState} from "vuex";
 
-    interface Data{
+    interface Computed {
+        currentProject: Project,
         options: DynamicFormMeta
     }
 
-    export default Vue.extend<Data, {}, {}, {}>({
+    export default Vue.extend<{}, {}, Computed, {}>({
         components: {DynamicForm},
-        data(): Data {
-            return {
-                options: baselineOptions
-            }
+        computed: {
+            ...mapState(["currentProject"]),
+          options:  {
+              get() {
+                  return this.currentProject.currentRegion.baselineOptions
+              },
+              set(value: DynamicFormMeta) {
+                  //TODO: update by calling a mutation to set options in the current region
+              }
+          }
         }
     });
-
-    //TODO: These should be fetched from the backend
-    const baselineOptions: DynamicFormMeta = {
-        controlSections: [
-            {
-                label: "Site Inputs",
-                controlGroups: [
-                    {
-                        controls: [
-                            {
-                                name: "population",
-                                label: "Population Size",
-                                type: "number",
-                                required: true,
-                                value: 1000,
-                                min: 1,
-                                max: 1e7
-                            }
-                        ]
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "seasonality",
-                                label: "Seasonality of transmission",
-                                type: "select",
-                                required: true,
-                                value: "seasonal",
-                                helpText: "Seasonal: a district with a transmission season.<br/>" +
-                                    "Perennial: a district with transmission throughout the year.",
-                                options: [
-                                    {id: "seasonal", label: "Seasonal"},
-                                    {id: "perennial", label: "Perennial"}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "prevalence",
-                                label: "Current malaria prevalence",
-                                type: "select",
-                                required: true,
-                                value: "low",
-                                helpText: "Low = less than 10% of children under 5-years have malaria<br/>" +
-                                    "Medium = approximately 30% of children under 5-years have malaria<br/>" +
-                                    "High = approximately 65% of children  under 5-years have malaria",
-                                options: [
-                                    {id: "low", label: "Low"},
-                                    {id: "med", label: "Medium"},
-                                    {id: "high", label: "High"}
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                label: "Mosquito Inputs",
-                controlGroups: [
-                    {
-                        controls: [
-                            {
-                                name: "biting_indoors",
-                                label: "Preference for biting indoors",
-                                type: "select",
-                                required: true,
-                                value: "high",
-                                helpText: "High: indicates ~97% bites taken when people are indoors.<br/>" +
-                                    "Low: indicates ~78% bites taken when people are indoors.",
-                                options: [
-                                    {id: "high", label: "High"},
-                                    {id: "low", label: "Low"}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "anthrophilic",
-                                label: "Preference for biting people",
-                                type: "select",
-                                required: true,
-                                value: "low",
-                                helpText: "High: ~92% of mosquito bites taken on humans.<br/>" +
-                                    "Low: ~74% of mosquito bites taken on humans.",
-                                options: [
-                                    {id: "low", label: "Low"},
-                                    {id: "high", label: "High"}
-                                ]
-                            },
-                        ]
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "resistance",
-                                label: "Level of pyrethoid resistance",
-                                type: "select",
-                                required: true,
-                                value: "0",
-                                helpText: "Mosquito survival in 24-hour WHO discriminatory dose bioassays.<br/>" +
-                                    "0% indicates all mosquitoes die and are susceptible to the pyrethroid insecticide in ITNs.<br/>" +
-                                    "100% indicates that no mosquitoes die or are susceptible to the pyrethroid insecticide in ITNs.<br/>" +
-                                    "Select the ranges that best represent the district. For example, if the district has susceptibility " +
-                                    "bioassay test estimates that range from 23% to 42% of mosquitoes being killed, then explore both 60% " +
-                                    "and 80% pyrethroid resistance scenarios.",
-                                options: [
-                                    {id: "0", label: "0"},
-                                    {id: "0.2", label: "20%"},
-                                    {id: "0.4", label: "40%"},
-                                    {id: "0.6", label: "60%"},
-                                    {id: "0.8", label: "80%"},
-                                    {id: "1", label: "100%"},
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "metabolic",
-                                label: "Evidence of PBO synergy",
-                                type: "select",
-                                required: true,
-                                value: "yes",
-                                helpText: "Yes: evidence that PBO (piperonyl butoxide) synergises pyrethroid insecticide.<br/>" +
-                                    "No: no evidence that PBO (piperonyl butoxide) synergises pyrethroid insecticide.",
-                                options: [
-                                    {id: "yes", label: "Yes"},
-                                    {id: "no", label: "No"}
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                label: "Past Vector Control",
-                controlGroups: [
-                    {
-                        controls: [
-                            {
-                                name: "net",
-                                label: "ITN population usage in last survey (%)",
-                                type: "select",
-                                required: true,
-                                value: "0",
-                                helpText: "The current endemicity of a zone is partly determined by the performance and " +
-                                    "quantity of vector control leading up to now. This is required to approximate the " +
-                                    "efficacy of interventions moving forward.",
-                                options: [
-                                    {id: "0", label: "0% usage"},
-                                    {id: "0.2", label: "20% usage"},
-                                    {id: "0.4", label: "40% usage"},
-                                    {id: "0.6", label: "60% usage"},
-                                    {id: "0.8", label: "80% usage"}
-                                ]
-                            }
-                        ],
-                    },
-                    {
-                        controls: [
-                            {
-                                name: "irs",
-                                label: "What was the estimated coverage of spray campaign (last year)",
-                                type: "select",
-                                required: true,
-                                value: "0",
-                                helpText: "If IRS was not used in the past year, select 0% coverage",
-                                options: [
-                                    {id: "0", label: "0% coverage"},
-                                    {id: "0.8", label: "80% coverage"}
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    };
-
 </script>

--- a/src/app/static/src/app/components/projectListPage.vue
+++ b/src/app/static/src/app/components/projectListPage.vue
@@ -46,6 +46,8 @@
     import {RootMutation} from "../mutations";
     import {mapMutationByName} from "../utils";
     import {Project} from "../models/project";
+    import {mapState} from "vuex";
+    import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
     interface Data {
         newProject: string
@@ -62,6 +64,7 @@
     interface Computed {
         disabled: boolean
         placeholder: string
+        baselineOptions: DynamicFormMeta
     }
 
     interface Tag {
@@ -78,12 +81,13 @@
             }
         },
         computed: {
+            ... mapState(["baselineOptions"]),
             disabled() {
                 return !this.newProject || (!this.newRegion && this.regions.length == 0)
             },
             placeholder() {
                 return this.regions.length == 0 ? "First region, second region" : "...";
-            }
+            },
         },
         methods: {
             addProject: mapMutationByName(RootMutation.AddProject),
@@ -95,7 +99,7 @@
                     // so take this.newRegion as the only region
                     regionNames.push(this.newRegion)
                 }
-                const project = new Project(this.newProject, regionNames);
+                const project = new Project(this.newProject, regionNames, null, this.baselineOptions);
                 this.addProject(project);
                 this.$router.push({
                     path: project.currentRegion.url

--- a/src/app/static/src/app/components/projectListPage.vue
+++ b/src/app/static/src/app/components/projectListPage.vue
@@ -99,7 +99,7 @@
                     // so take this.newRegion as the only region
                     regionNames.push(this.newRegion)
                 }
-                const project = new Project(this.newProject, regionNames, null, this.baselineOptions);
+                const project = new Project(this.newProject, regionNames, this.baselineOptions);
                 this.addProject(project);
                 this.$router.push({
                     path: project.currentRegion.url

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -1,12 +1,16 @@
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+
 export interface Region {
     name: string
     url: string
+    baselineOptions: DynamicFormMeta
 }
 
 export class Region {
-    constructor(name: string, parent: Project) {
-        this.name = name
-        this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase()
+    constructor(name: string, parent: Project, baselineOptions: DynamicFormMeta) {
+        this.name = name;
+        this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
+        this.baselineOptions = baselineOptions;
     }
 }
 
@@ -18,9 +22,9 @@ export interface Project {
 
 export class Project {
 
-    constructor(name: string, regionsName: string[], currentRegion: Region | null = null) {
+    constructor(name: string, regionsName: string[], currentRegion: Region | null = null, baselineOptions: DynamicFormMeta) {
         this.name = name;
-        this.regions = regionsName.map(n => new Region(n, this));
+        this.regions = regionsName.map(n => new Region(n, this, baselineOptions));
         this.currentRegion = currentRegion || this.regions[0]
     }
 

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -10,7 +10,7 @@ export class Region {
     constructor(name: string, parent: Project, baselineOptions: DynamicFormMeta) {
         this.name = name;
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
-        this.baselineOptions = baselineOptions;
+        this.baselineOptions = {...baselineOptions}; //Make our own copy
     }
 }
 

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -1,4 +1,5 @@
 import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {deepCopy} from "../utils";
 
 export interface Region {
     name: string
@@ -10,7 +11,7 @@ export class Region {
     constructor(name: string, parent: Project, baselineOptions: DynamicFormMeta) {
         this.name = name;
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
-        this.baselineOptions = {...baselineOptions}; //Make our own copy
+        this.baselineOptions = deepCopy(baselineOptions);
     }
 }
 
@@ -22,7 +23,7 @@ export interface Project {
 
 export class Project {
 
-    constructor(name: string, regionsName: string[], currentRegion: Region | null = null, baselineOptions: DynamicFormMeta) {
+    constructor(name: string, regionsName: string[], baselineOptions: DynamicFormMeta, currentRegion: Region | null = null) {
         this.name = name;
         this.regions = regionsName.map(n => new Region(n, this, baselineOptions));
         this.currentRegion = currentRegion || this.regions[0]

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -3,11 +3,13 @@ import {RootState} from "./store";
 import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph} from "./generated";
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 export enum RootMutation {
     AddProject = "AddProject",
     SetCurrentRegion = "SetCurrentRegion",
     AddError = "AddError",
+    AddBaselineOptions = "AddBaselineOptions",
     AddPrevalenceGraphData = "AddPrevalenceGraphData",
     AddPrevalenceGraphConfig = "AddPrevalenceGraphConfig"
 }
@@ -25,6 +27,10 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.AddError](state: RootState, payload: APIError) {
         state.errors.push(payload)
+    },
+
+    [RootMutation.AddBaselineOptions](state: RootState, payload: DynamicFormMeta) {
+        state.baselineOptions = payload
     },
 
     [RootMutation.AddPrevalenceGraphData](state: RootState, payload: Data) {

--- a/src/app/static/src/app/store.ts
+++ b/src/app/static/src/app/store.ts
@@ -6,11 +6,13 @@ import {mutations} from "./mutations";
 import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph} from "./generated";
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 export interface RootState {
     projects: Project[]
     currentProject: Project | null
     errors: APIError[]
+    baselineOptions: DynamicFormMeta | null
     prevalenceGraphData: Data
     prevalenceGraphConfig: Graph | null
 }
@@ -27,7 +29,8 @@ const storeOptions: StoreOptions<RootState> = {
         currentProject: null,
         errors: [],
         prevalenceGraphData: [],
-        prevalenceGraphConfig: null
+        prevalenceGraphConfig: null,
+        baselineOptions: null
     },
     mutations,
     plugins: [logger]

--- a/src/app/static/src/app/store.ts
+++ b/src/app/static/src/app/store.ts
@@ -7,6 +7,7 @@ import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph} from "./generated";
 import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {actions} from "./actions";
 
 export interface RootState {
     projects: Project[]
@@ -32,9 +33,10 @@ const storeOptions: StoreOptions<RootState> = {
         prevalenceGraphConfig: null,
         baselineOptions: null
     },
+    actions,
     mutations,
     plugins: [logger]
-}
+};
 
 Vue.use(Vuex);
 export const store = new Vuex.Store<RootState>(storeOptions);

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -17,9 +17,11 @@ export function isMINTResponseFailure(object: any): object is ResponseFailure {
 }
 
 export function deepCopy(data: any): any {
-    let result = null;
-    if(!data) return result;
+    if (data == null) {
+        return null;
+    }
 
+    let result = null;
     if(Array.isArray(data)) {
         result = [];
         for (let item of data) {

--- a/src/app/static/src/app/utils.ts
+++ b/src/app/static/src/app/utils.ts
@@ -16,6 +16,27 @@ export function isMINTResponseFailure(object: any): object is ResponseFailure {
         && object.errors.every((e: any) => isMINTError(e))
 }
 
+export function deepCopy(data: any): any {
+    let result = null;
+    if(!data) return result;
+
+    if(Array.isArray(data)) {
+        result = [];
+        for (let item of data) {
+            result.push(deepCopy(item));
+        }
+    } else if (typeof data === "object") {
+        result = {} as any;
+        for(let prop in data) {
+            if (data.hasOwnProperty(prop)) {
+                result[prop] = deepCopy(data[prop]);
+            }
+        }
+    }
+
+    return result || data;
+}
+
 export const freezer = {
 
     deepFreeze: (data: any): any => {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -26,7 +26,7 @@ describe("app", () => {
     it("show second nav bar if currentProject is not null", () => {
         let state = {
             currentProject: new Project(
-                "my project", ["region1", "region2"], null, {controlSections: []}
+                "my project", ["region1", "region2"], {controlSections: []}
             )
         };
         const wrapper = getWrapper(state);

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -3,7 +3,6 @@ import {shallowMount} from "@vue/test-utils";
 import app from "../../app/components/app.vue";
 import {mockRootState} from "../mocks";
 import {Project} from "../../app/models/project";
-import {RootMutation} from "../../app/mutations";
 import {RootAction} from "../../app/actions";
 
 describe("app", () => {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -3,15 +3,20 @@ import {shallowMount} from "@vue/test-utils";
 import app from "../../app/components/app.vue";
 import {mockRootState} from "../mocks";
 import {Project} from "../../app/models/project";
+import {RootMutation} from "../../app/mutations";
+import {RootAction} from "../../app/actions";
 
 describe("app", () => {
 
-    const getWrapper = (state = {}) => {
+    const getWrapper = (state = {}, fetchOptionsMock = jest.fn()) => {
         const store = new Vuex.Store({
-            state: mockRootState(state)
-        })
+            state: mockRootState(state),
+            actions: {
+                [RootAction.FetchBaselineOptions]: fetchOptionsMock
+            }
+        });
         return shallowMount(app, {store, stubs: ['router-link', 'router-view']});
-    }
+    };
 
     it("does not show second nav bar if currentProject is null", () => {
         const wrapper = getWrapper();
@@ -21,7 +26,7 @@ describe("app", () => {
     it("show second nav bar if currentProject is not null", () => {
         let state = {
             currentProject: new Project(
-                "my project", ["region1", "region2"]
+                "my project", ["region1", "region2"], null, {controlSections: []}
             )
         };
         const wrapper = getWrapper(state);
@@ -33,6 +38,13 @@ describe("app", () => {
         expect(firstNavLink.html())
             .toBe("<router-link-stub to=\"/projects/my-project/regions/region1\"" +
                 " class=\"text-success\">region1</router-link-stub>");
+    });
+
+    it("fetches baseline options", () => {
+        const fetchOptionsMock = jest.fn();
+        const wrapper = getWrapper({}, fetchOptionsMock);
+
+        expect(fetchOptionsMock.mock.calls.length).toBe(1);
     });
 
 });

--- a/src/app/static/src/tests/components/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline.test.ts
@@ -17,7 +17,7 @@ describe("baseline", () => {
     const getWrapper = (addProjectMock = jest.fn()) => {
         const store =  new Vuex.Store({
             state: mockRootState({
-                currentProject: new Project("project 1", ["region 1"], null, baselineOptions)
+                currentProject: new Project("project 1", ["region 1"], baselineOptions)
             })
         });
 

--- a/src/app/static/src/tests/components/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline.test.ts
@@ -1,12 +1,31 @@
 import {shallowMount} from "@vue/test-utils";
 import {DynamicForm} from "@reside-ic/vue-dynamic-form";
 import Baseline from "../../app/components/baseline.vue";
-
+import Vuex from "vuex";
+import {mockRootState} from "../mocks";
+import {Project} from "../../app/models/project";
 
 describe("baseline", () => {
 
-    it("renders dynamic form", () => {
-        const wrapper = shallowMount(Baseline);
+    const baselineOptions = {
+        controlSections: [
+            { label: "section1", controlGroups: [] },
+            { label: "section2", controlGroups: [] },
+            { label: "section3", controlGroups: [] }
+        ]
+    };
+    const getWrapper = (addProjectMock = jest.fn()) => {
+        const store =  new Vuex.Store({
+            state: mockRootState({
+                currentProject: new Project("project 1", ["region 1"], null, baselineOptions)
+            })
+        });
+
+        return shallowMount(Baseline, {store});
+    };
+
+    it("renders baseline options from current region", () => {
+        const wrapper = getWrapper();
         expect(wrapper.find(DynamicForm).exists()).toBe(true);
         expect(wrapper.find(DynamicForm).props("formMeta").controlSections.length).toBe(3);
     });

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -93,8 +93,8 @@ describe("project page", () => {
             currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
         });
 
-        //Baseline options should equal options from store, but be fresh copy
-        expect(mockMutation.mock.calls[0][1].currentRegion.baselineOptions).not.toBe(mockBaselineOptions);
+        //Baseline options should equal options from store, but be fresh deep copy
+        expect(mockMutation.mock.calls[0][1].currentRegion.baselineOptions.controlSections).not.toBe(mockBaselineOptions.controlSections);
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");
     });

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -5,12 +5,17 @@ import VueTagsInput from '@johmun/vue-tags-input';
 import projectListPage from "../../app/components/projectListPage.vue";
 import {mockRootState} from "../mocks";
 import {RootMutation} from "../../app/mutations";
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("project page", () => {
 
+    const mockBaselineOptions: DynamicFormMeta = { controlSections: [] };
+
     const createStore = (addProjectMock = jest.fn()) => {
         return new Vuex.Store({
-            state: mockRootState(),
+            state: mockRootState({
+                baselineOptions: mockBaselineOptions
+            }),
             mutations: {
                 [RootMutation.AddProject]: addProjectMock
             }
@@ -18,7 +23,7 @@ describe("project page", () => {
     };
 
     it("button is disabled if project name is missing", async () => {
-        const store = createStore()
+        const store = createStore();
         const wrapper = shallowMount(projectListPage, {store});
 
         wrapper.find(VueTagsInput).vm.$emit("tagsChanged", [{text: "South"}])
@@ -30,9 +35,9 @@ describe("project page", () => {
     });
 
     it("button is disabled if regions and newRegion are missing", async () => {
-        const store = createStore()
+        const store = createStore();
         const wrapper = shallowMount(projectListPage, {store});
-        wrapper.find("input").setValue("new project")
+        wrapper.find("input").setValue("new project");
 
         await Vue.nextTick();
 
@@ -41,7 +46,7 @@ describe("project page", () => {
     });
 
     it("button is enabled when project name and regions are provided", async () => {
-        const store = createStore()
+        const store = createStore();
         const wrapper = shallowMount(projectListPage, {store});
 
         wrapper.find("input").setValue("new project");
@@ -54,7 +59,7 @@ describe("project page", () => {
     });
 
     it("button is enabled when project name and newRegion are provided", async () => {
-        const store = createStore()
+        const store = createStore();
         const wrapper = shallowMount(projectListPage, {store});
 
         wrapper.find("input").setValue("new project");
@@ -84,8 +89,8 @@ describe("project page", () => {
         expect(mockMutation.mock.calls.length).toBe(1);
         expect(mockMutation.mock.calls[0][1]).toEqual({
             name: "new project",
-            regions: [{name: "South", url: "/projects/new-project/regions/south"}],
-            currentRegion: {name: "South", url: "/projects/new-project/regions/south"}
+            regions: [{name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}],
+            currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
         });
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");
@@ -109,8 +114,8 @@ describe("project page", () => {
         expect(mockMutation.mock.calls.length).toBe(1);
         expect(mockMutation.mock.calls[0][1]).toEqual({
             name: "new project",
-            regions: [{name: "South", url: "/projects/new-project/regions/south"}],
-            currentRegion: {name: "South", url: "/projects/new-project/regions/south"}
+            regions: [{name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}],
+            currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
         });
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -93,6 +93,9 @@ describe("project page", () => {
             currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
         });
 
+        //Baseline options should equal options from store, but be fresh copy
+        expect(mockMutation.mock.calls[0][1].currentRegion.baselineOptions).not.toBe(mockBaselineOptions);
+
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");
     });
 

--- a/src/app/static/src/tests/components/regionPage.test.ts
+++ b/src/app/static/src/tests/components/regionPage.test.ts
@@ -3,7 +3,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import VueRouter from "vue-router";
 import regionPage from "../../app/components/regionPage.vue";
-import {mockRootState} from "../mocks";
+import {mockProject, mockRootState} from "../mocks";
 import {RootMutation} from "../../app/mutations";
 import stepButton from "../../app/components/stepButton.vue";
 import interventions from "../../app/components/interventions.vue";
@@ -17,7 +17,9 @@ describe("region page", () => {
 
     const createStore = (setCurrentRegionMock = jest.fn()) => {
         return new Vuex.Store({
-            state: mockRootState(),
+            state: mockRootState({
+                currentProject: mockProject()
+            }),
             mutations: {
                 [RootMutation.SetCurrentRegion]: setCurrentRegionMock
             }
@@ -33,7 +35,7 @@ describe("region page", () => {
 
         await router.push({
             path: "/projects/new-project/regions/new-region"
-        })
+        });
         await Vue.nextTick();
         expect(setCurrentRegionMock.mock.calls.length).toBe(1);
         expect(setCurrentRegionMock.mock.calls[0][1]).toBe("/projects/new-project/regions/new-region");

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -1,5 +1,6 @@
 import {actions, RootAction} from "../../app/actions";
 import {RootMutation} from "../../app/mutations";
+import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("actions", () => {
 
@@ -8,7 +9,7 @@ describe("actions", () => {
         await (actions[RootAction.FetchPrevalenceGraphData] as any)({commit} as any);
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddPrevalenceGraphData);
-        const firstRow = commit.mock.calls[0][1][0]
+        const firstRow = commit.mock.calls[0][1][0];
         expect(Object.keys(firstRow).sort())
             .toEqual([
                 "intervention",
@@ -29,4 +30,14 @@ describe("actions", () => {
         expect(commit.mock.calls[0][1].layout.title).toBeDefined(); // just confirm it's the expected type
     });
 
+    it("can get baseline options", async () => {
+        const commit = jest.fn();
+
+        await(actions[RootAction.FetchBaselineOptions] as any)({commit} as any);
+
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddBaselineOptions);
+        const options = commit.mock.calls[0][1] as DynamicFormMeta;
+        expect(options.controlSections.length).toBe(3);
+        expect(options.controlSections[0].label).toBe("Site Inputs");
+    });
 });

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -9,6 +9,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         projects: [],
         currentProject: null,
         errors: [],
+        baselineOptions: null,
         prevalenceGraphData: [],
         prevalenceGraphConfig: null,
         ...state

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -18,7 +18,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
 }
 
 export function mockProject(project: Partial<Project> = {}): Project {
-    return new Project("project 1", ["region 1"], null, {controlSections: []});
+    return new Project("project 1", ["region 1"], {controlSections: []});
 }
 
 export const mockSuccess = (data: any): ResponseSuccess => {

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -3,6 +3,7 @@ import MockAdapter from "axios-mock-adapter";
 import {RootState} from "../app/store";
 import {ResponseFailure, ResponseSuccess} from "../app/generated";
 import {APIError} from "../app/apiService";
+import {Project} from "../app/models/project";
 
 export function mockRootState(state: Partial<RootState> = {}): RootState {
     return {
@@ -14,6 +15,10 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         prevalenceGraphConfig: null,
         ...state
     }
+}
+
+export function mockProject(project: Partial<Project> = {}): Project {
+    return new Project("project 1", ["region 1"], null, {controlSections: []});
 }
 
 export const mockSuccess = (data: any): ResponseSuccess => {

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -19,6 +19,18 @@ describe("actions", () => {
         expectAllDefined(RootAction, actions);
     });
 
+    it("fetches baseline options", async () => {
+        const options = {"configurationSections":[]};
+        mockAxios.onGet("/baseline/options")
+            .reply(200, mockSuccess(options));
+
+        const commit = jest.fn();
+        await (actions[RootAction.FetchBaselineOptions] as any)({commit} as any);
+
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddBaselineOptions);
+        expect(commit.mock.calls[0][1]).toStrictEqual(options);
+    });
+
     it("fetches prevalence graph data", async () => {
         mockAxios.onPost("/impact/graph/prevalence/data")
             .reply(200, mockSuccess([{prev: 1, net_use: 0.2, resistance: "low"}]));

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -25,12 +25,14 @@ describe("mutations", () => {
 
     it("updates the current region", () => {
         const state = mockRootState({
-            currentProject: new Project("my project", ["North region", "South region"])
-        })
+            currentProject: new Project("my project", ["North region", "South region"],
+                null, {controlSections: []})
+        });
         mutations[RootMutation.SetCurrentRegion](state, "/projects/my-project/regions/south-region");
         expect(state.currentProject!!.currentRegion).toEqual({
             name: "South region",
-            url: "/projects/my-project/regions/south-region"
+            url: "/projects/my-project/regions/south-region",
+            baselineOptions: {controlSections: []}
         })
     });
 

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -42,6 +42,14 @@ describe("mutations", () => {
         expect(state.errors[0].detail).toBe("some message detail");
     });
 
+    it("adds baseline options", () => {
+        const state = mockRootState();
+        const options = {"configurationSections":[]};
+        mutations[RootMutation.AddBaselineOptions](state, options);
+
+        expect(state.baselineOptions).toStrictEqual(options);
+    });
+
     it("adds prevalence graph data", () => {
         const state = mockRootState();
         mutations[RootMutation.AddPrevalenceGraphData](state, ["some data"]);

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -26,7 +26,7 @@ describe("mutations", () => {
     it("updates the current region", () => {
         const state = mockRootState({
             currentProject: new Project("my project", ["North region", "South region"],
-                null, {controlSections: []})
+                {controlSections: []})
         });
         mutations[RootMutation.SetCurrentRegion](state, "/projects/my-project/regions/south-region");
         expect(state.currentProject!!.currentRegion).toEqual({

--- a/src/app/static/src/tests/utils.test.ts
+++ b/src/app/static/src/tests/utils.test.ts
@@ -91,9 +91,13 @@ describe("utils", () => {
 
         const data = {
             nothing: null,
+            truth: true,
             time: 10,
             name: "hello",
-            items: [1, null, "three", {label: "l1"}],
+            untrue: false,
+            zero: 0,
+            empty: "",
+            items: [1, null, "three", {label: "l1"}, 0, false, ""],
             child: {
                 name: "child",
                 items: [4, null, "five"]

--- a/src/app/static/src/tests/utils.test.ts
+++ b/src/app/static/src/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import {freezer, isMINTResponseFailure} from "../app/utils";
+import {freezer, isMINTResponseFailure, deepCopy} from "../app/utils";
 import {mockError} from "./mocks";
 
 describe("utils", () => {
@@ -85,6 +85,27 @@ describe("utils", () => {
             expect(isMINTResponseFailure(test)).toBe(true);
         });
 
+    });
+
+    it("deep copies an object", () => {
+
+        const data = {
+            nothing: null,
+            time: 10,
+            name: "hello",
+            items: [1, null, "three", {label: "l1"}],
+            child: {
+                name: "child",
+                items: [4, null, "five"]
+            }
+        };
+
+        const copy = deepCopy(data);
+        expect(JSON.stringify(copy)).toEqual(JSON.stringify(data));
+        expect(copy.items).not.toBe(data.items);
+        expect(copy.items[3]).not.toBe(data.items[3]);
+        expect(copy.child).not.toBe(data.child);
+        expect(copy.child.items).not.toBe(data.child.items);
     });
 
 });


### PR DESCRIPTION
This PR:
- Fetches baseline options from the backend on initialise and saves to store
- Creates a copy of these options on each new region
- Displays the current region's options in the baseline form
- Saving and submitting options to be done in future tickets