### PR TITLE
mrc-1525 add intervention settings sidebar

### DIFF
--- a/src/app/static/src/app/components/interventions.vue
+++ b/src/app/static/src/app/components/interventions.vue
@@ -1,30 +1,36 @@
 <template>
-    <div>
-        <ul class="nav nav-tabs" style="margin-left: 26px;margin-bottom: -1px;">
-            <li class="nav-item">
-                <a class="text-success nav-link"
-                   :class="{active: activeHorizontalTab === 'Impact'}"
-                   @click="() => changeHorizontalTab('Impact')">Impact
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="text-success nav-link"
-                   :class="{active: activeHorizontalTab === 'Cost'}"
-                   @click="() => changeHorizontalTab('Cost')">Cost effectiveness
-                </a>
-            </li>
-        </ul>
-        <div class="tab-content">
-            <vertical-tabs :tabs="verticalTabs"
-                           :active-tab="activeVerticalTab"
-                           @tab-selected="changeVerticalTab">
-                <div v-if="activeHorizontalTab === 'Impact'">
-                    <impact :active-tab="activeVerticalTab"/>
-                </div>
-                <div v-if="activeHorizontalTab === 'Cost'">
-                    <cost-effectiveness :active-tab="activeVerticalTab"/>
-                </div>
-            </vertical-tabs>
+    <div class="row">
+        <div class="col-4 interventions">
+            <dynamic-form v-model="options"
+                          :include-submit-button="false"></dynamic-form>
+        </div>
+        <div class="col-8">
+            <ul class="nav nav-tabs" style="margin-left: 26px;margin-bottom: -1px;">
+                <li class="nav-item">
+                    <a class="text-success nav-link"
+                       :class="{active: activeHorizontalTab === 'Impact'}"
+                       @click="() => changeHorizontalTab('Impact')">Impact
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="text-success nav-link"
+                       :class="{active: activeHorizontalTab === 'Cost'}"
+                       @click="() => changeHorizontalTab('Cost')">Cost effectiveness
+                    </a>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <vertical-tabs :tabs="verticalTabs"
+                               :active-tab="activeVerticalTab"
+                               @tab-selected="changeVerticalTab">
+                    <div v-if="activeHorizontalTab === 'Impact'">
+                        <impact :active-tab="activeVerticalTab"/>
+                    </div>
+                    <div v-if="activeHorizontalTab === 'Cost'">
+                        <cost-effectiveness :active-tab="activeVerticalTab"/>
+                    </div>
+                </vertical-tabs>
+            </div>
         </div>
     </div>
 </template>
@@ -35,6 +41,9 @@
     import {RootAction} from "../actions";
     import impact from "./impact.vue";
     import costEffectiveness from "./costEffectiveness.vue";
+    import {mapState} from "vuex";
+    import {DynamicForm, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+    import {Project} from "../models/project";
 
     interface ComponentData {
         verticalTabs: string[],
@@ -48,12 +57,28 @@
         fetchData: () => void
     }
 
-    export default Vue.extend<ComponentData, Methods, {}, {}>({
+    interface Computed {
+        currentProject: Project,
+        options: DynamicFormMeta
+    }
+
+    export default Vue.extend<ComponentData, Methods, Computed, {}>({
         data() {
             return {
                 verticalTabs: ["Table", "Graphs"],
                 activeVerticalTab: "Graphs",
                 activeHorizontalTab: "Impact"
+            }
+        },
+        computed: {
+            ...mapState(["currentProject"]),
+            options: {
+                get() {
+                    return this.currentProject.currentRegion.interventionOptions
+                },
+                set(value: DynamicFormMeta) {
+                    // TODO update
+                }
             }
         },
         methods: {
@@ -65,7 +90,7 @@
             },
             fetchData: mapActionByName(RootAction.FetchImpactData)
         },
-        components: {verticalTabs, impact, costEffectiveness},
+        components: {verticalTabs, impact, costEffectiveness, DynamicForm},
         mounted() {
             this.fetchData();
         }

--- a/src/app/static/src/app/components/projectListPage.vue
+++ b/src/app/static/src/app/components/projectListPage.vue
@@ -65,6 +65,7 @@
         disabled: boolean
         placeholder: string
         baselineOptions: DynamicFormMeta
+        interventionOptions: DynamicFormMeta
     }
 
     interface Tag {
@@ -81,7 +82,7 @@
             }
         },
         computed: {
-            ... mapState(["baselineOptions"]),
+            ... mapState(["baselineOptions", "interventionOptions"]),
             disabled() {
                 return !this.newProject || (!this.newRegion && this.regions.length == 0)
             },
@@ -99,7 +100,7 @@
                     // so take this.newRegion as the only region
                     regionNames.push(this.newRegion)
                 }
-                const project = new Project(this.newProject, regionNames, this.baselineOptions);
+                const project = new Project(this.newProject, regionNames, this.baselineOptions, this.interventionOptions);
                 this.addProject(project);
                 this.$router.push({
                     path: project.currentRegion.url

--- a/src/app/static/src/app/components/regionPage.vue
+++ b/src/app/static/src/app/components/regionPage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mx-5 mt-5">
+    <div class="container-fluid my-5">
         <div class="stepper mb-5">
             <step-button number="1"
                          text="Setup baseline"

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -5,13 +5,18 @@ export interface Region {
     name: string
     url: string
     baselineOptions: DynamicFormMeta
+    interventionOptions: DynamicFormMeta
 }
 
 export class Region {
-    constructor(name: string, parent: Project, baselineOptions: DynamicFormMeta) {
+    constructor(name: string,
+                parent: Project,
+                baselineOptions: DynamicFormMeta,
+                interventionOptions: DynamicFormMeta) {
         this.name = name;
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
         this.baselineOptions = deepCopy(baselineOptions);
+        this.interventionOptions = deepCopy(interventionOptions);
     }
 }
 
@@ -23,9 +28,13 @@ export interface Project {
 
 export class Project {
 
-    constructor(name: string, regionsName: string[], baselineOptions: DynamicFormMeta, currentRegion: Region | null = null) {
+    constructor(name: string,
+                regionsName: string[],
+                baselineOptions: DynamicFormMeta,
+                interventionOptions: DynamicFormMeta,
+                currentRegion: Region | null = null) {
         this.name = name;
-        this.regions = regionsName.map(n => new Region(n, this, baselineOptions));
+        this.regions = regionsName.map(n => new Region(n, this, baselineOptions, interventionOptions));
         this.currentRegion = currentRegion || this.regions[0]
     }
 

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -4,6 +4,7 @@ import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph, TableDefinition} from "./generated";
 import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {deepCopy} from "./utils";
 
 export enum RootMutation {
     AddProject = "AddProject",
@@ -31,7 +32,7 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.SetCurrentRegionBaselineOptions](state: RootState, payload: DynamicFormMeta) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.baselineOptions = payload;
+            state.currentProject.currentRegion.baselineOptions = deepCopy(payload);
         }
     },
 
@@ -45,9 +46,6 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.AddInterventionOptions](state: RootState, payload: DynamicFormMeta) {
         state.interventionOptions = payload
-        if (state.currentProject) {
-            state.currentProject.currentRegion.interventionOptions = payload;
-        }
     },
 
     [RootMutation.AddPrevalenceGraphData](state: RootState, payload: Data) {

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -4,7 +4,6 @@ import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph, TableDefinition} from "./generated";
 import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
-import {deepCopy} from "./utils";
 
 export enum RootMutation {
     AddProject = "AddProject",
@@ -32,7 +31,7 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.SetCurrentRegionBaselineOptions](state: RootState, payload: DynamicFormMeta) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.baselineOptions = deepCopy(payload);
+            state.currentProject.currentRegion.baselineOptions = payload;
         }
     },
 

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -45,6 +45,9 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.AddInterventionOptions](state: RootState, payload: DynamicFormMeta) {
         state.interventionOptions = payload
+        if (state.currentProject) {
+            state.currentProject.currentRegion.interventionOptions = payload;
+        }
     },
 
     [RootMutation.AddPrevalenceGraphData](state: RootState, payload: Data) {

--- a/src/app/static/src/scss/partials/interventions.scss
+++ b/src/app/static/src/scss/partials/interventions.scss
@@ -1,0 +1,51 @@
+.interventions {
+  .dynamic-form {
+    @extend .list-group;
+
+    > div {
+      @extend .list-group-item;
+      padding-left: 0;
+      padding-right: 0;
+      padding-top: 0;
+
+      h3 {
+        @extend .bg-light;
+        @extend .text-secondary;
+        @extend .list-group-item;
+        @extend .border-left-0;
+        @extend .border-right-0;
+        @extend .border-top-0;
+        font-size: inherit !important;
+      }
+
+      .row {
+        display: block;
+        margin: 0;
+      }
+
+      .col-md-6 {
+        display: flex;
+        @extend .row;
+        max-width: 100%;
+        flex: 0 0 100%;
+
+        span.small {
+          display: none;
+        }
+      }
+
+      label {
+        @extend .col-7;
+        @extend .col-form-label;
+        @extend .text-right;
+        padding-left: 0;
+      }
+
+      input, select {
+        display: flex;
+        @extend .col-5;
+        @extend .mt-2;
+      }
+    }
+  }
+}

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -4,6 +4,7 @@
 @import "partials/stepper.scss";
 @import "partials/tooltips.scss";
 @import "partials/baseline.scss";
+@import "partials/interventions.scss";
 
 html {
   overflow-y: scroll;

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -26,7 +26,7 @@ describe("app", () => {
     it("show second nav bar if currentProject is not null", () => {
         let state = {
             currentProject: new Project(
-                "my project", ["region1", "region2"], {controlSections: []}
+                "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
             )
         };
         const wrapper = getWrapper(state);

--- a/src/app/static/src/tests/components/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline.test.ts
@@ -19,7 +19,7 @@ describe("baseline", () => {
     const getWrapper = (setBaselineMock = jest.fn()) => {
         const store =  new Vuex.Store({
             state: mockRootState({
-                currentProject: new Project("project 1", ["region 1"], baselineOptions)
+                currentProject: new Project("project 1", ["region 1"], baselineOptions, {controlSections: []})
             }),
             mutations: {
                 [RootMutation.SetCurrentRegionBaselineOptions]: setBaselineMock

--- a/src/app/static/src/tests/components/interventions.test.ts
+++ b/src/app/static/src/tests/components/interventions.test.ts
@@ -2,15 +2,16 @@ import Vue from "vue";
 import {mount, shallowMount} from "@vue/test-utils";
 import interventions from "../../app/components/interventions.vue";
 import Vuex from "vuex";
-import {mockRootState} from "../mocks";
+import {mockProject, mockRootState} from "../mocks";
 import {RootState} from "../../app/store";
 import {RootAction} from "../../app/actions";
 import impact from "../../app/components/impact.vue";
 import costEffectiveness from "../../app/components/costEffectiveness.vue";
+import {DynamicForm} from "@reside-ic/vue-dynamic-form";
 
 describe("interventions", () => {
 
-    const createStore = (state: Partial<RootState> = {},
+    const createStore = (state: Partial<RootState> = {currentProject: mockProject()},
                          mockFetchData = jest.fn()) => {
         return new Vuex.Store({
             state: mockRootState(state),
@@ -71,9 +72,29 @@ describe("interventions", () => {
 
     it("fetches data", async () => {
         const mockFetch = jest.fn();
-        const store = createStore({}, mockFetch);
+        const store = createStore({currentProject: mockProject()}, mockFetch);
         shallowMount(interventions, {store});
         expect(mockFetch.mock.calls.length).toBe(1);
+    });
+
+    it("renders intervention options", async () => {
+        const project = mockProject()
+        project.currentRegion
+            .interventionOptions
+            .controlSections.push({controlGroups: [], label: "S1"})
+        const store = createStore({currentProject: project});
+        const wrapper = shallowMount(interventions, {store});
+        const form = wrapper.find(DynamicForm);
+        expect(form.exists()).toBe(true);
+        expect(form.props("includeSubmitButton")).toBe(false);
+        expect(form.props("formMeta")).toEqual({
+            controlSections: [
+                {
+                    controlGroups: [],
+                    label: "S1"
+                }
+            ]
+        });
     });
 
 });

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -9,12 +9,14 @@ import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("project page", () => {
 
-    const mockBaselineOptions: DynamicFormMeta = { controlSections: [] };
+    const mockBaselineOptions: DynamicFormMeta = {controlSections: []};
+    const mockInterventionOptions: DynamicFormMeta = {controlSections: []};
 
     const createStore = (addProjectMock = jest.fn()) => {
         return new Vuex.Store({
             state: mockRootState({
-                baselineOptions: mockBaselineOptions
+                baselineOptions: mockBaselineOptions,
+                interventionOptions: mockInterventionOptions
             }),
             mutations: {
                 [RootMutation.AddProject]: addProjectMock
@@ -89,12 +91,23 @@ describe("project page", () => {
         expect(mockMutation.mock.calls.length).toBe(1);
         expect(mockMutation.mock.calls[0][1]).toEqual({
             name: "new project",
-            regions: [{name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}],
-            currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
+            regions: [{
+                name: "South", url: "/projects/new-project/regions/south",
+                baselineOptions: mockBaselineOptions,
+                interventionOptions: mockInterventionOptions
+            }],
+            currentRegion: {
+                name: "South", url: "/projects/new-project/regions/south",
+                baselineOptions: mockBaselineOptions,
+                interventionOptions: mockInterventionOptions
+            }
         });
 
-        //Baseline options should equal options from store, but be fresh deep copy
-        expect(mockMutation.mock.calls[0][1].currentRegion.baselineOptions.controlSections).not.toBe(mockBaselineOptions.controlSections);
+        // options should equal options from store, but be fresh deep copy
+        expect(mockMutation.mock.calls[0][1].currentRegion.baselineOptions.controlSections)
+            .not.toBe(mockBaselineOptions.controlSections);
+        expect(mockMutation.mock.calls[0][1].currentRegion.interventionOptions.controlSections)
+            .not.toBe(mockInterventionOptions.controlSections);
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");
     });
@@ -117,8 +130,18 @@ describe("project page", () => {
         expect(mockMutation.mock.calls.length).toBe(1);
         expect(mockMutation.mock.calls[0][1]).toEqual({
             name: "new project",
-            regions: [{name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}],
-            currentRegion: {name: "South", url: "/projects/new-project/regions/south", baselineOptions: mockBaselineOptions}
+            regions: [{
+                name: "South",
+                url: "/projects/new-project/regions/south",
+                baselineOptions: mockBaselineOptions,
+                interventionOptions: mockInterventionOptions
+            }],
+            currentRegion: {
+                name: "South",
+                url: "/projects/new-project/regions/south",
+                baselineOptions: mockBaselineOptions,
+                interventionOptions: mockInterventionOptions
+            }
         });
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -34,7 +34,7 @@ export function mockGraph(props: Partial<Graph> = {}): Graph {
 }
 
 export function mockProject(): Project {
-    return new Project("project 1", ["region 1"], {controlSections: []});
+    return new Project("project 1", ["region 1"], {controlSections: []}, {controlSections: []});
 }
 
 export const mockSuccess = (data: any): ResponseSuccess => {

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -27,20 +27,21 @@ describe("mutations", () => {
     it("updates the current region", () => {
         const state = mockRootState({
             currentProject: new Project("my project", ["North region", "South region"],
-                {controlSections: []})
+                {controlSections: []}, {controlSections: []})
         });
         mutations[RootMutation.SetCurrentRegion](state, "/projects/my-project/regions/south-region");
         expect(state.currentProject!!.currentRegion).toEqual({
             name: "South region",
             url: "/projects/my-project/regions/south-region",
-            baselineOptions: {controlSections: []}
+            baselineOptions: {controlSections: []},
+            interventionOptions: {controlSections:[]}
         })
     });
 
     it("updates the current region's baseline options", () => {
         const state = mockRootState({
             currentProject: new Project("my project", ["North region", "South region"],
-                {controlSections: ["OLD BASELINE"]} as any)
+                {controlSections: ["OLD BASELINE"]} as any, {controlSections: []})
         });
 
         const newBaseline = {controlSections: ["NEWBASELINE"]} as any;
@@ -50,7 +51,7 @@ describe("mutations", () => {
 
     it("updating the current region's baseline options does nothing if no current project", () => {
         const projects = [new Project("my project", ["North region", "South region"],
-            {controlSections: ["OLD BASELINE"]} as any)];
+            {controlSections: ["OLD BASELINE"]} as any, {controlSections: []})];
         const state = mockRootState({
             projects,
             currentProject: null


### PR DESCRIPTION
* adds intervention options as a property on each region, as with baseline options
* adds the intervention options to the region page as another dynamic form 
* some css torturing to make it look right (including restyling cols as rows, it all feels a bit wrong, would def be nice to refactor the dynamic form package to make it more agnostic about the layout!)