### PR TITLE
mrc-1526 persist and use intervention settings

### DIFF
--- a/src/app/static/src/app/components/figures/filteredData.ts
+++ b/src/app/static/src/app/components/figures/filteredData.ts
@@ -9,7 +9,7 @@ export interface FilteringProps {
 export function useFiltering(props: FilteringProps) {
     const filterBySettings = (row: any) => {
         for (let key of Object.keys(props.settings)) {
-            if (row[key] != undefined && row[key] != props.settings[key]) {
+            if (row[key] == undefined || row[key] != props.settings[key]) {
                 return false;
             }
         }

--- a/src/app/static/src/app/components/figures/filteredData.ts
+++ b/src/app/static/src/app/components/figures/filteredData.ts
@@ -8,7 +8,6 @@ export interface FilteringProps {
 
 export function useFiltering(props: FilteringProps) {
 
-
     const filterBySettings = (row: any) => {
         for (let key of Object.keys(props.settings)) {
             if (row[key] != undefined && (props.settings[key] === "" || row[key] != props.settings[key])) {

--- a/src/app/static/src/app/components/figures/filteredData.ts
+++ b/src/app/static/src/app/components/figures/filteredData.ts
@@ -7,9 +7,11 @@ export interface FilteringProps {
 }
 
 export function useFiltering(props: FilteringProps) {
+
+
     const filterBySettings = (row: any) => {
         for (let key of Object.keys(props.settings)) {
-            if (row[key] == undefined || row[key] != props.settings[key]) {
+            if (row[key] != undefined && (props.settings[key] === "" || row[key] != props.settings[key])) {
                 return false;
             }
         }

--- a/src/app/static/src/app/components/impact.vue
+++ b/src/app/static/src/app/components/impact.vue
@@ -15,21 +15,19 @@
 </template>
 <script lang="ts">
     import Vue from "vue";
-    import { mapStateProp} from "../utils";
+    import {mapStateProp} from "../utils";
     import {RootState} from "../store";
     import {Data, Graph, TableDefinition} from "../generated";
     import plotlyGraph from "./figures/graphs/plotlyGraph.vue";
     import dynamicTable from "./figures/dynamicTable.vue";
+    import {DynamicFormData} from "@reside-ic/vue-dynamic-form";
 
     export default Vue.extend({
         components: {plotlyGraph, dynamicTable},
         props: ["activeTab"],
-        data() {
-            return {
-                settings: {'net_use': 0, 'irs_use': 0}
-            }
-        },
         computed: {
+            settings: mapStateProp<RootState, DynamicFormData | null>
+            (state => state.currentProject && state.currentProject.currentRegion.interventionSettings),
             prevalenceGraphConfig: mapStateProp<RootState, Graph | null>(state => state.prevalenceGraphConfig),
             prevalenceGraphData: mapStateProp<RootState, Data>(state => state.prevalenceGraphData),
             tableData: mapStateProp<RootState, Data>(state => state.impactTableData),

--- a/src/app/static/src/app/components/interventions.vue
+++ b/src/app/static/src/app/components/interventions.vue
@@ -104,6 +104,7 @@
         watch: {
             options() {
                 this.$nextTick(() => {
+                    // wait til the next tick so that the form has been updated
                     (this.$refs.settings as any).submit();
                 })
             }

--- a/src/app/static/src/app/components/interventions.vue
+++ b/src/app/static/src/app/components/interventions.vue
@@ -1,7 +1,8 @@
 <template>
     <div class="row">
         <div class="col-4 interventions">
-            <dynamic-form v-model="options"
+            <dynamic-form ref="settings"
+                          v-model="options"
                           :include-submit-button="false"></dynamic-form>
         </div>
         <div class="col-8">
@@ -37,13 +38,14 @@
 <script lang="ts">
     import Vue from "vue";
     import verticalTabs from "./verticalTabs.vue";
-    import {mapActionByName} from "../utils";
+    import {mapActionByName, mapMutationByName} from "../utils";
     import {RootAction} from "../actions";
     import impact from "./impact.vue";
     import costEffectiveness from "./costEffectiveness.vue";
     import {mapState} from "vuex";
-    import {DynamicForm, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+    import {DynamicForm, DynamicFormMeta, DynamicFormData} from "@reside-ic/vue-dynamic-form";
     import {Project} from "../models/project";
+    import {RootMutation} from "../mutations";
 
     interface ComponentData {
         verticalTabs: string[],
@@ -55,6 +57,8 @@
         changeVerticalTab: (name: string) => void
         changeHorizontalTab: (name: string) => void
         fetchData: () => void
+        updateInterventionOptions:
+            (payload: { formMeta: DynamicFormMeta, formData: DynamicFormData }) => void
     }
 
     interface Computed {
@@ -77,7 +81,8 @@
                     return this.currentProject.currentRegion.interventionOptions
                 },
                 set(value: DynamicFormMeta) {
-                    // TODO update
+                    const data = (this.$refs.settings as any).submit();
+                    this.updateInterventionOptions({formMeta: value, formData: data});
                 }
             }
         },
@@ -88,7 +93,8 @@
             changeHorizontalTab(name: string) {
                 this.activeHorizontalTab = name;
             },
-            fetchData: mapActionByName(RootAction.FetchImpactData)
+            fetchData: mapActionByName(RootAction.FetchImpactData),
+            updateInterventionOptions: mapMutationByName(RootMutation.SetCurrentRegionInterventionOptions)
         },
         components: {verticalTabs, impact, costEffectiveness, DynamicForm},
         mounted() {

--- a/src/app/static/src/app/components/interventions.vue
+++ b/src/app/static/src/app/components/interventions.vue
@@ -3,6 +3,7 @@
         <div class="col-4 interventions">
             <dynamic-form ref="settings"
                           v-model="options"
+                          @submit="updateInterventionSettings"
                           :include-submit-button="false"></dynamic-form>
         </div>
         <div class="col-8">
@@ -43,7 +44,7 @@
     import impact from "./impact.vue";
     import costEffectiveness from "./costEffectiveness.vue";
     import {mapState} from "vuex";
-    import {DynamicForm, DynamicFormMeta, DynamicFormData} from "@reside-ic/vue-dynamic-form";
+    import {DynamicForm, DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
     import {Project} from "../models/project";
     import {RootMutation} from "../mutations";
 
@@ -57,8 +58,8 @@
         changeVerticalTab: (name: string) => void
         changeHorizontalTab: (name: string) => void
         fetchData: () => void
-        updateInterventionOptions:
-            (payload: { formMeta: DynamicFormMeta, formData: DynamicFormData }) => void
+        updateInterventionOptions: (payload: DynamicFormMeta) => void
+        updateInterventionSettings: (payload: DynamicFormData) => void
     }
 
     interface Computed {
@@ -81,8 +82,7 @@
                     return this.currentProject.currentRegion.interventionOptions
                 },
                 set(value: DynamicFormMeta) {
-                    const data = (this.$refs.settings as any).submit();
-                    this.updateInterventionOptions({formMeta: value, formData: data});
+                    this.updateInterventionOptions(value);
                 }
             }
         },
@@ -94,11 +94,19 @@
                 this.activeHorizontalTab = name;
             },
             fetchData: mapActionByName(RootAction.FetchImpactData),
-            updateInterventionOptions: mapMutationByName(RootMutation.SetCurrentRegionInterventionOptions)
+            updateInterventionOptions: mapMutationByName(RootMutation.SetCurrentRegionInterventionOptions),
+            updateInterventionSettings: mapMutationByName(RootMutation.SetCurrentRegionInterventionSettings)
         },
         components: {verticalTabs, impact, costEffectiveness, DynamicForm},
         mounted() {
             this.fetchData();
+        },
+        watch: {
+            options() {
+                this.$nextTick(() => {
+                    (this.$refs.settings as any).submit();
+                })
+            }
         }
     });
 

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -1,11 +1,13 @@
 import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {deepCopy} from "../utils";
+import {Dictionary} from "vue-router/types/router";
 
 export interface Region {
     name: string
     url: string
     baselineOptions: DynamicFormMeta
     interventionOptions: DynamicFormMeta
+    interventionSettings: Dictionary<any>
 }
 
 export class Region {
@@ -17,6 +19,7 @@ export class Region {
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
         this.baselineOptions = deepCopy(baselineOptions);
         this.interventionOptions = deepCopy(interventionOptions);
+        this.interventionSettings = {}
     }
 }
 

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -19,8 +19,16 @@ export class Region {
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
         this.baselineOptions = deepCopy(baselineOptions);
         this.interventionOptions = deepCopy(interventionOptions);
-        this.interventionSettings = {}
+        this.interventionSettings =  {}
+        this.interventionOptions.controlSections.map(s => {
+            s.controlGroups.map(g => {
+                g.controls.map(c => {
+                    this.interventionSettings[c.name] = null;
+                })
+            })
+        });
     }
+
 }
 
 export interface Project {

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -1,13 +1,12 @@
-import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {deepCopy} from "../utils";
-import {Dictionary} from "vue-router/types/router";
 
 export interface Region {
     name: string
     url: string
     baselineOptions: DynamicFormMeta
     interventionOptions: DynamicFormMeta
-    interventionSettings: Dictionary<any>
+    interventionSettings: DynamicFormData
 }
 
 export class Region {

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -3,13 +3,14 @@ import {RootState} from "./store";
 import {Project} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph, TableDefinition} from "./generated";
-import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 import {deepCopy} from "./utils";
 
 export enum RootMutation {
     AddProject = "AddProject",
     SetCurrentRegion = "SetCurrentRegion",
     SetCurrentRegionBaselineOptions = "SetCurrentRegionBaselineOptions",
+    SetCurrentRegionInterventionOptions = "SetCurrentRegionInterventionOptions",
     AddError = "AddError",
     AddBaselineOptions = "AddBaselineOptions",
     AddInterventionOptions = "AddInterventionOptions",
@@ -33,6 +34,17 @@ export const mutations: MutationTree<RootState> = {
     [RootMutation.SetCurrentRegionBaselineOptions](state: RootState, payload: DynamicFormMeta) {
         if (state.currentProject) {
             state.currentProject.currentRegion.baselineOptions = deepCopy(payload);
+        }
+    },
+
+    [RootMutation.SetCurrentRegionInterventionOptions](state: RootState,
+                                                       payload: {
+                                                           formMeta: DynamicFormMeta,
+                                                           formData: DynamicFormData
+                                                       }) {
+        if (state.currentProject) {
+            state.currentProject.currentRegion.interventionOptions = deepCopy(payload.formMeta)
+            state.currentProject.currentRegion.interventionSettings = payload.formData
         }
     },
 

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -11,6 +11,7 @@ export enum RootMutation {
     SetCurrentRegion = "SetCurrentRegion",
     SetCurrentRegionBaselineOptions = "SetCurrentRegionBaselineOptions",
     SetCurrentRegionInterventionOptions = "SetCurrentRegionInterventionOptions",
+    SetCurrentRegionInterventionSettings="SetCurrentRegionInterventionSettings",
     AddError = "AddError",
     AddBaselineOptions = "AddBaselineOptions",
     AddInterventionOptions = "AddInterventionOptions",
@@ -38,13 +39,16 @@ export const mutations: MutationTree<RootState> = {
     },
 
     [RootMutation.SetCurrentRegionInterventionOptions](state: RootState,
-                                                       payload: {
-                                                           formMeta: DynamicFormMeta,
-                                                           formData: DynamicFormData
-                                                       }) {
+                                                       payload: DynamicFormMeta) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.interventionOptions = deepCopy(payload.formMeta)
-            state.currentProject.currentRegion.interventionSettings = payload.formData
+            state.currentProject.currentRegion.interventionOptions = deepCopy(payload)
+        }
+    },
+
+    [RootMutation.SetCurrentRegionInterventionSettings](state: RootState, payload: DynamicFormData) {
+        if (state.currentProject) {
+            console.log(payload)
+            state.currentProject.currentRegion.interventionSettings = payload
         }
     },
 

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -34,20 +34,19 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.SetCurrentRegionBaselineOptions](state: RootState, payload: DynamicFormMeta) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.baselineOptions = deepCopy(payload);
+            state.currentProject.currentRegion.baselineOptions = payload
         }
     },
 
     [RootMutation.SetCurrentRegionInterventionOptions](state: RootState,
                                                        payload: DynamicFormMeta) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.interventionOptions = deepCopy(payload)
+            state.currentProject.currentRegion.interventionOptions = payload
         }
     },
 
     [RootMutation.SetCurrentRegionInterventionSettings](state: RootState, payload: DynamicFormData) {
         if (state.currentProject) {
-            console.log(payload)
             state.currentProject.currentRegion.interventionSettings = payload
         }
     },

--- a/src/app/static/src/tests/components/figures/filteredDataTests.ts
+++ b/src/app/static/src/tests/components/figures/filteredDataTests.ts
@@ -1,0 +1,60 @@
+import {useFiltering} from "../../../app/components/figures/filteredData";
+
+describe("use filtering", () => {
+
+    it("returns no rows if there are invalid settings selected", () => {
+
+        const props = {
+            settings: {
+                "intervention": "none",
+                "net_use": null
+            },
+            data: [
+                {"month": 1, "intervention": "none", "net_use": 0, "value": 0.1},
+                {"month": 1, "intervention": "none", "net_use": 0.1, "value": 0.2},
+                {"month": 2, "intervention": "none", "net_use": 0, "value": 0.3},
+                {"month": 2, "intervention": "none", "net_use": 0.1, "value": 0.4},
+                {"month": 1, "intervention": "ITN", "net_use": 0, "value": 0.5},
+                {"month": 1, "intervention": "ITN", "net_use": 0.1, "value": 0.6},
+                {"month": 2, "intervention": "ITN", "net_use": 0, "value": 0.7},
+                {"month": 2, "intervention": "ITN", "net_use": 0.1, "value": 0.8}
+            ]
+        }
+
+        let result = useFiltering(props);
+        expect(result.filteredData.value.length).toBe(0);
+
+        props.settings.net_use = "";
+        result = useFiltering(props);
+        expect(result.filteredData.value.length).toBe(0);
+
+        props.settings.net_use = 0;
+        result = useFiltering(props);
+        expect(result.filteredData.value.length).toBe(2);
+
+    });
+
+    it("ignores settings that don't exist in the data", () => {
+
+        const props = {
+            settings: {
+                "intervention": "none",
+                "other_setting": 12
+            },
+            data: [
+                {"month": 1, "intervention": "none", "net_use": 0, "value": 0.1},
+                {"month": 1, "intervention": "none", "net_use": 0.1, "value": 0.2},
+                {"month": 2, "intervention": "none", "net_use": 0, "value": 0.3},
+                {"month": 2, "intervention": "none", "net_use": 0.1, "value": 0.4},
+                {"month": 1, "intervention": "ITN", "net_use": 0, "value": 0.5},
+                {"month": 1, "intervention": "ITN", "net_use": 0.1, "value": 0.6},
+                {"month": 2, "intervention": "ITN", "net_use": 0, "value": 0.7},
+                {"month": 2, "intervention": "ITN", "net_use": 0.1, "value": 0.8}
+            ]
+        }
+
+        const result = useFiltering(props);
+        expect(result.filteredData.value.length).toBe(4);
+    });
+
+});

--- a/src/app/static/src/tests/components/impact.test.ts
+++ b/src/app/static/src/tests/components/impact.test.ts
@@ -1,7 +1,7 @@
 import Vuex from "vuex";
 import {shallowMount} from "@vue/test-utils";
 import impact from "../../app/components/impact.vue";
-import {mockGraph, mockRootState} from "../mocks";
+import {mockGraph, mockProject, mockRootState} from "../mocks";
 import plotlyGraph from "../../app/components/figures/graphs/plotlyGraph.vue";
 import {RootState} from "../../app/store";
 import dynamicTable from "../../app/components/figures/dynamicTable.vue";
@@ -15,7 +15,10 @@ describe("impact", () => {
     };
 
     it("shows prevalence graph under graph tab if graph config exists", () => {
+        const project = mockProject();
+        project.currentRegion.interventionSettings = {"test": 1}
         const store = createStore({
+            currentProject: project,
             prevalenceGraphConfig: mockGraph({
                 layout: {
                     whatever: 1
@@ -43,7 +46,10 @@ describe("impact", () => {
         expect(graph.props("series")).toEqual([{
             x: [1, 2],
             y: [100, 200]
-        }])
+        }]);
+        expect(graph.props("settings")).toEqual({
+            "test": 1
+        });
     });
 
     it("does not show prevalence graph under table tab", () => {
@@ -59,7 +65,10 @@ describe("impact", () => {
     });
 
     it("shows table under table tab if table config exists", () => {
+        const project = mockProject();
+        project.currentRegion.interventionSettings = {"test": 1}
         const store = createStore({
+            currentProject: project,
             impactTableConfig: {"col": "Column name"},
             impactTableData: [{col: 1}]
         });
@@ -68,6 +77,7 @@ describe("impact", () => {
         const table = wrapper.findAll(dynamicTable).at(0);
         expect(table.props("columns")).toEqual({"col": "Column name"});
         expect(table.props("data")).toEqual([{col: 1}]);
+        expect(table.props("settings")).toEqual({"test": 1});
     });
 
     it("does not show table under graph tab", () => {

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -10,7 +10,16 @@ import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 describe("project page", () => {
 
     const mockBaselineOptions: DynamicFormMeta = {controlSections: []};
-    const mockInterventionOptions: DynamicFormMeta = {controlSections: []};
+    const mockInterventionOptions: DynamicFormMeta = {
+        controlSections: [{
+            label: "S1",
+            controlGroups: [{
+                controls: [
+                    {name: "c1", type: "number", required: true}
+                ]
+            }]
+        }]
+    };
 
     const createStore = (addProjectMock = jest.fn()) => {
         return new Vuex.Store({
@@ -94,12 +103,14 @@ describe("project page", () => {
             regions: [{
                 name: "South", url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
-                interventionOptions: mockInterventionOptions
+                interventionOptions: mockInterventionOptions,
+                interventionSettings: {"c1": null}
             }],
             currentRegion: {
                 name: "South", url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
-                interventionOptions: mockInterventionOptions
+                interventionOptions: mockInterventionOptions,
+                interventionSettings: {"c1": null}
             }
         });
 
@@ -134,13 +145,15 @@ describe("project page", () => {
                 name: "South",
                 url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
-                interventionOptions: mockInterventionOptions
+                interventionOptions: mockInterventionOptions,
+                interventionSettings: {"c1": null}
             }],
             currentRegion: {
                 name: "South",
                 url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
-                interventionOptions: mockInterventionOptions
+                interventionOptions: mockInterventionOptions,
+                interventionSettings: {"c1": null}
             }
         });
 

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -2,7 +2,7 @@ import {mutations, RootMutation} from "../../app/mutations";
 import {mockError, mockRootState} from "../mocks";
 import {Project} from "../../app/models/project";
 import {expectAllDefined} from "../testHelpers";
-import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("mutations", () => {
 
@@ -34,7 +34,8 @@ describe("mutations", () => {
             name: "South region",
             url: "/projects/my-project/regions/south-region",
             baselineOptions: {controlSections: []},
-            interventionOptions: {controlSections:[]}
+            interventionOptions: {controlSections:[]},
+            interventionSettings: {}
         })
     });
 
@@ -87,7 +88,6 @@ describe("mutations", () => {
         expect(state.interventionOptions).toStrictEqual(options);
     });
 
-
     it("adds prevalence graph data", () => {
         const state = mockRootState();
         mutations[RootMutation.AddPrevalenceGraphData](state, ["some data"]);
@@ -114,5 +114,43 @@ describe("mutations", () => {
         mutations[RootMutation.AddImpactTableConfig](state, ["some data"]);
 
         expect(state.impactTableConfig).toStrictEqual(["some data"]);
+    });
+
+    it("updates the current region's intervention options", () => {
+        const state = mockRootState({
+            currentProject: new Project("my project", ["North region", "South region"],
+                {controlSections: []}, {controlSections: []})
+        });
+
+        const newOptions: DynamicFormMeta = {controlSections: [{label: "s1", controlGroups: []}]};
+        mutations[RootMutation.SetCurrentRegionInterventionOptions](state, newOptions);
+        expect(state.currentProject!!.currentRegion.interventionOptions)
+            .toEqual(newOptions);
+    });
+
+    it("updating the current region's baseline options does nothing if no current project", () => {
+        const state = mockRootState();
+        const newOptions: DynamicFormMeta = {controlSections: [{label: "s1", controlGroups: []}]};
+        mutations[RootMutation.SetCurrentRegionInterventionOptions](state, newOptions);
+        expect(state.currentProject).toBeNull();
+    });
+
+    it("updates the current region's intervention settings", () => {
+        const state = mockRootState({
+            currentProject: new Project("my project", ["North region", "South region"],
+                {controlSections: []}, {controlSections: []})
+        });
+
+        const newSettings: DynamicFormData = {"c1": 3};
+        mutations[RootMutation.SetCurrentRegionInterventionSettings](state, newSettings);
+        expect(state.currentProject!!.currentRegion.interventionSettings)
+            .toEqual(newSettings);
+    });
+
+    it("updating the current region's intervention settings does nothing if not current project", () => {
+        const state = mockRootState();
+        const newSettings: DynamicFormData = {"c1": 3};
+        mutations[RootMutation.SetCurrentRegionInterventionSettings](state, newSettings);
+        expect(state.currentProject).toBeNull();
     });
 });


### PR DESCRIPTION
Contains commits from https://github.com/mrc-ide/mint/pull/34

As well as keeping track of the form meta object, we ultimately want the selected options in the form of a dictionary of values `{name: value}`, in other words a `DynamicFormData` object. I could see a couple of ways of doing this. 

One way would be to have the current region's settings as a computed property on a component or as a store getter. But the `DynamicForm` already keeps track of the controls and contains all the logic to build up the form data object, so I've gone with triggering the form's "submit" event to get the data and then just storing it in the store under region.

 The upside - don't have to duplicate logic that already exist, keeps it easy to test (especially avoiding getters and the testing overhead they bring!). The downside of this is it might be confusing to have both `interventionOptions`: `DynamicFormMeta` and `interventionSettings`: `DynamicFormData` on the region objects. 

See what you think.