### PR TITLE
mrc-1588 Dynamic load js for pages, and async load interventions js

### DIFF
--- a/src/app/static/src/app/components/regionPage.vue
+++ b/src/app/static/src/app/components/regionPage.vue
@@ -23,8 +23,10 @@
     import {RootMutation} from "../mutations";
     import {mapMutationByName} from "../utils";
     import stepButton from "./stepButton.vue";
-    import interventions from "./interventions.vue";
-    import baseline from "./baseline.vue";
+    // @ts-ignore
+    const baseline = () => import("./baseline.vue");
+    // @ts-ignore
+    const interventions = async () => import("./interventions.vue");
 
     export default Vue.extend({
         components: {stepButton, baseline, interventions},
@@ -43,4 +45,6 @@
             }
         }
     });
+
+    interventions().then(); //async load js from server
 </script>

--- a/src/app/static/src/app/components/regionPage.vue
+++ b/src/app/static/src/app/components/regionPage.vue
@@ -23,8 +23,7 @@
     import {RootMutation} from "../mutations";
     import {mapMutationByName} from "../utils";
     import stepButton from "./stepButton.vue";
-    // @ts-ignore
-    const baseline = () => import("./baseline.vue");
+    import baseline from "./baseline.vue";
     // @ts-ignore
     const interventions = async () => import("./interventions.vue");
 

--- a/src/app/static/src/app/router.ts
+++ b/src/app/static/src/app/router.ts
@@ -1,12 +1,14 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-import projectListPage from "./components/projectListPage.vue";
-import regionPage from "./components/regionPage.vue";
+// @ts-ignore
+const projectListPage = () => import("./components/projectListPage.vue");
+// @ts-ignore
+const regionPage = () => import("./components/regionPage.vue");
 
 const routes = [
     {path: "/", component: projectListPage},
     {path: "/projects/:project/regions/:region", component: regionPage}
-]
+];
 
 export const router = new VueRouter({
     mode: "history",

--- a/src/app/static/src/app/router.ts
+++ b/src/app/static/src/app/router.ts
@@ -1,7 +1,6 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-// @ts-ignore
-const projectListPage = () => import("./components/projectListPage.vue");
+import projectListPage from "./components/projectListPage.vue";
 // @ts-ignore
 const regionPage = () => import("./components/regionPage.vue");
 

--- a/src/app/static/src/tests/components/regionPage.test.ts
+++ b/src/app/static/src/tests/components/regionPage.test.ts
@@ -44,7 +44,8 @@ describe("region page", () => {
     it("sets current step when step is clicked", async () => {
 
         const store = createStore();
-        const wrapper = mount(regionPage, {localVue, store, router});
+        const stubs = ["interventions"];
+        const wrapper = mount(regionPage, {localVue, store, router, stubs});
         const steps = wrapper.findAll(stepButton);
 
         const buttons = wrapper.findAll("button");
@@ -54,7 +55,7 @@ describe("region page", () => {
 
         expect(steps.at(1).props("active")).toBe(true);
         expect(steps.at(0).props("active")).toBe(false);
-        expect(wrapper.findAll(interventions).length).toBe(1);
+        expect(wrapper.findAll("interventions-stub").length).toBe(1);
         expect(wrapper.findAll(baseline).length).toBe(0);
 
         buttons.at(0).trigger("click");
@@ -63,14 +64,15 @@ describe("region page", () => {
 
         expect(steps.at(0).props("active")).toBe(true);
         expect(steps.at(1).props("active")).toBe(false);
-        expect(wrapper.findAll(interventions).length).toBe(0);
+        expect(wrapper.findAll("interventions-stub").length).toBe(0);
         expect(wrapper.findAll(baseline).length).toBe(1);
 
     });
 
     it("sets current step to 2 when baseline is submitted", async () => {
         const store = createStore();
-        const wrapper = shallowMount(regionPage, {store});
+        const stubs = ["interventions"];
+        const wrapper = shallowMount(regionPage, {store, stubs});
 
         const baselineComp = wrapper.find(baseline);
         baselineComp.vm.$emit("submit");
@@ -80,7 +82,7 @@ describe("region page", () => {
         const steps = wrapper.findAll(stepButton);
         expect(steps.at(1).props("active")).toBe(true);
         expect(steps.at(0).props("active")).toBe(false);
-        expect(wrapper.findAll(interventions).length).toBe(1);
+        expect(wrapper.findAll("interventions-stub").length).toBe(1);
         expect(wrapper.findAll(baseline).length).toBe(0);
     });
 

--- a/src/app/static/src/tests/components/regionPage.test.ts
+++ b/src/app/static/src/tests/components/regionPage.test.ts
@@ -45,12 +45,13 @@ describe("region page", () => {
         project.currentRegion.step = 2;
 
         const store = createStore(jest.fn(), jest.fn(), project);
-        const wrapper = shallowMount(regionPage,{store});
+        const stubs = ["interventions"];
+        const wrapper = shallowMount(regionPage,{store, stubs});
 
         const steps = wrapper.findAll(stepButton);
         expect(steps.at(1).props("active")).toBe(true);
         expect(steps.at(0).props("active")).toBe(false);
-        expect(wrapper.findAll(interventions).length).toBe(1);
+        expect(wrapper.findAll("interventions-stub").length).toBe(1);
         expect(wrapper.findAll(baseline).length).toBe(0);
     });
 
@@ -70,21 +71,14 @@ describe("region page", () => {
     });
 
     it("sets current step when step is clicked", async () => {
-        const stubs = ["interventions"];
         const mockSetRegionStep = jest.fn();
         const store = createStore(jest.fn(), mockSetRegionStep);
-        const wrapper = mount(regionPage, {localVue, store, router, stubs});
+        const wrapper = mount(regionPage, {localVue, store, router});
 
         const buttons = wrapper.findAll("button");
         buttons.at(1).trigger("click");
 
         await Vue.nextTick();
-
-        const steps = wrapper.findAll(stepButton);
-        expect(steps.at(1).props("active")).toBe(true);
-        expect(steps.at(0).props("active")).toBe(false);
-        expect(wrapper.findAll("interventions-stub").length).toBe(1);
-        expect(wrapper.findAll(baseline).length).toBe(0);
 
         expect(mockSetRegionStep.mock.calls.length).toBe(1);
         expect(mockSetRegionStep.mock.calls[0][1]).toBe(2);
@@ -93,10 +87,6 @@ describe("region page", () => {
 
         await Vue.nextTick();
 
-        expect(steps.at(0).props("active")).toBe(true);
-        expect(steps.at(1).props("active")).toBe(false);
-        expect(wrapper.findAll("interventions-stub").length).toBe(0);
-        expect(wrapper.findAll(baseline).length).toBe(1);
         expect(mockSetRegionStep.mock.calls.length).toBe(2);
         expect(mockSetRegionStep.mock.calls[1][1]).toBe(1);
 
@@ -105,20 +95,13 @@ describe("region page", () => {
     it("sets current step to 2 when baseline is submitted", async () => {
         const mockSetRegionStep = jest.fn();
         const store = createStore(jest.fn(), mockSetRegionStep);
-        const stubs = ["interventions"];
-        const wrapper = shallowMount(regionPage, {store, stubs});
+        const wrapper = shallowMount(regionPage, {store});
 
         const baselineComp = wrapper.find(baseline);
         baselineComp.vm.$emit("submit");
 
         await Vue.nextTick();
 
-        const steps = wrapper.findAll(stepButton);
-        expect(steps.at(1).props("active")).toBe(true);
-        expect(steps.at(0).props("active")).toBe(false);
-
-        expect(wrapper.findAll("interventions-stub").length).toBe(1);
-        expect(wrapper.findAll(baseline).length).toBe(0);
         expect(mockSetRegionStep.mock.calls.length).toBe(1);
         expect(mockSetRegionStep.mock.calls[0][1]).toBe(2);
     });


### PR DESCRIPTION
What seemed to be causing a delay (of around 2s) when loading the front page wasn't fetching the options but actually fetching our own compiled app.js.

I followed the advice here, to split up the compiled js with dynamic imports:
https://vuedose.tips/tips/dynamic-imports-in-vue-js-for-better-performance/

I split out regionPage, and also, within regionPage, the interventions component. It's the interventions that takes the time, the js for that seems to be 4.8MB. I suspect the issue may be plotly, but not sure there's much we can do about that. 

Of course, this just moved the problem so that the delay now happened when you moved from baseline to interventions. So I added a line into region page to immediately initiate an async import of the interventions. This seemed to do the trick. See how you think it compares.  