### PR TITLE
mrc-1593 Fetch data only when necessary

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -7615,8 +7615,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7637,14 +7636,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7659,20 +7656,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7789,8 +7783,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7802,7 +7795,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7817,7 +7809,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7825,14 +7816,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7851,7 +7840,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -7913,8 +7901,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -7942,8 +7929,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7955,7 +7941,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8033,8 +8018,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8070,7 +8054,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8090,7 +8073,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8134,14 +8116,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -12,7 +12,7 @@ export enum RootAction {
     FetchImpactTableConfig = "FetchImpactTableConfig",
     FetchBaselineOptions = "FetchBaselineOptions",
     FetchInterventionOptions = "FetchInterventionOptions",
-    FetchImpactData = "FetchImpactData",
+    EnsureImpactData = "EnsureImpactData",
     FetchConfig = "FetchConfig"
 }
 
@@ -67,11 +67,14 @@ export const actions: ActionTree<RootState, RootState> = {
             .get<Data>("/impact/table/config")
     },
 
-    async [RootAction.FetchImpactData](context) {
-        await Promise.all([
-            context.dispatch(RootAction.FetchPrevalenceGraphData),
-            context.dispatch(RootAction.FetchImpactTableData)
-        ]);
+    async [RootAction.EnsureImpactData](context) {
+        const project = context.state.currentProject;
+        if (project && (!project.currentRegion.impactTableData.length || !project.currentRegion.prevalenceGraphData.length)) {
+            await Promise.all([
+                context.dispatch(RootAction.FetchPrevalenceGraphData),
+                context.dispatch(RootAction.FetchImpactTableData)
+            ]);
+        }
     },
 
     async [RootAction.FetchConfig](context) {

--- a/src/app/static/src/app/components/interventions.vue
+++ b/src/app/static/src/app/components/interventions.vue
@@ -54,7 +54,7 @@
     interface Methods {
         changeVerticalTab: (name: string) => void
         changeHorizontalTab: (name: string) => void
-        fetchData: () => void
+        ensureData: () => void
     }
 
     interface Computed {
@@ -92,15 +92,15 @@
             changeHorizontalTab(name: string) {
                 this.activeHorizontalTab = name;
             },
-            fetchData: mapActionByName(RootAction.FetchImpactData)
+            ensureData: mapActionByName(RootAction.EnsureImpactData)
         },
         components: {verticalTabs, impact, costEffectiveness, DynamicForm},
         mounted() {
-            this.fetchData();
+            this.ensureData();
         },
         watch: {
             currentRegion: function () {
-                this.fetchData();
+                this.ensureData();
             }
         }
     });

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -32,6 +32,10 @@ export const mutations: MutationTree<RootState> = {
     [RootMutation.SetCurrentRegionBaselineOptions](state: RootState, payload: DynamicFormMeta) {
         if (state.currentProject) {
             state.currentProject.currentRegion.baselineOptions = payload;
+
+            //Invalidate current region data
+            state.currentProject.currentRegion.impactTableData = [];
+            state.currentProject.currentRegion.prevalenceGraphData = [];
         }
     },
 

--- a/src/app/static/src/tests/components/interventions.test.ts
+++ b/src/app/static/src/tests/components/interventions.test.ts
@@ -12,11 +12,11 @@ import {DynamicForm} from "@reside-ic/vue-dynamic-form";
 describe("interventions", () => {
 
     const createStore = (state: Partial<RootState> = {currentProject: mockProject()},
-                         mockFetchData = jest.fn()) => {
+                         mockEnsureData = jest.fn()) => {
         return new Vuex.Store({
             state: mockRootState(state),
             actions: {
-                [RootAction.FetchImpactData]: mockFetchData
+                [RootAction.EnsureImpactData]: mockEnsureData
             }
         });
     };

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -27,7 +27,9 @@ describe("actions", () => {
     const state = {
         currentProject: {
             currentRegion: {
-                baselineOptions: options
+                baselineOptions: options,
+                prevalenceGraphData: [],
+                impactTableData: []
             }
         }
     };
@@ -122,12 +124,63 @@ describe("actions", () => {
         expect(dispatch.mock.calls[3][0]).toBe(RootAction.FetchImpactTableConfig);
     });
 
-    it("FetchImpactTableData fetches all impact figure data", async () => {
+    it("EnsureImpactData fetches all impact figure data if none already present", async () => {
         const dispatch = jest.fn();
-        await (actions[RootAction.FetchImpactData] as any)({dispatch} as any);
+        await (actions[RootAction.EnsureImpactData] as any)({dispatch, state} as any);
 
         expect(dispatch.mock.calls[0][0]).toBe(RootAction.FetchPrevalenceGraphData);
         expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchImpactTableData);
+    });
+
+    it("EnsureImpactData fetches all impact figure data if graph not already present", async () => {
+        const dispatch = jest.fn();
+        const stateWithoutImpactGraph = {
+            currentProject: {
+                currentRegion: {
+                    baselineOptions: options,
+                    prevalenceGraphData: [],
+                    impactTableData: ["TEST TABLE DATA"] as any
+                }
+            }
+        };
+        await (actions[RootAction.EnsureImpactData] as any)({dispatch, state: stateWithoutImpactGraph} as any);
+
+        expect(dispatch.mock.calls[0][0]).toBe(RootAction.FetchPrevalenceGraphData);
+        expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchImpactTableData);
+    });
+
+    it("EnsureImpactData fetches all impact figure data if table not already present", async () => {
+        const dispatch = jest.fn();
+        const stateWithoutImpactTable = {
+            currentProject: {
+                currentRegion: {
+                    baselineOptions: options,
+                    prevalenceGraphData: ["TEST GRAPH DATA"] as any,
+                    impactTableData: []
+                }
+            }
+        };
+        await (actions[RootAction.EnsureImpactData] as any)({dispatch, state: stateWithoutImpactTable} as any);
+
+        expect(dispatch.mock.calls[0][0]).toBe(RootAction.FetchPrevalenceGraphData);
+        expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchImpactTableData);
+
+    });
+
+    it("EnsureImpactData does not fetch impact figure data if all data already present", async () => {
+        const dispatch = jest.fn();
+        const stateWithAllImpactData = {
+            currentProject: {
+                currentRegion: {
+                    baselineOptions: options,
+                    prevalenceGraphData: ["TEST GRAPH DATA"] as any,
+                    impactTableData: ["TEST TABLE DATA"] as any
+                }
+            }
+        };
+        await (actions[RootAction.EnsureImpactData] as any)({dispatch, state: stateWithAllImpactData} as any);
+
+        expect(dispatch.mock.calls.length).toBe(0);
     });
 
 });

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -51,6 +51,20 @@ describe("mutations", () => {
         expect(state.currentProject!!.currentRegion.baselineOptions).toStrictEqual(newBaseline);
     });
 
+    it("updating the current region's baseline options invalidates data", () => {
+        const state = mockRootState({
+            currentProject: new Project("my project", ["North region", "South region"],
+                {controlSections: ["OLD BASELINE"]} as any, {controlSections: []})
+        });
+        state.currentProject!!.currentRegion.prevalenceGraphData = ["TEST GRAPH DATA"] as any;
+        state.currentProject!!.currentRegion.impactTableData = ["TEST TABLE DATA"] as any;
+
+        const newBaseline = {controlSections: ["NEWBASELINE"]} as any;
+        mutations[RootMutation.SetCurrentRegionBaselineOptions](state, newBaseline);
+        expect(state.currentProject!!.currentRegion.prevalenceGraphData).toStrictEqual([]);
+        expect(state.currentProject!!.currentRegion.impactTableData).toStrictEqual([]);
+    });
+
     it("updating the current region's baseline options does nothing if no current project", () => {
         const projects = [new Project("my project", ["North region", "South region"],
             {controlSections: ["OLD BASELINE"]} as any, {controlSections: []})];


### PR DESCRIPTION
It's necessary to fetch data if it hasn't been fetched yet, or if the baseline settings have changed since last fetch. Make this simple by invalidating the data (resetting it to empty arrays) whenever the baseline settings change, and only fetch when data is required if the data held is empty. Hence the FetchImpactData action becomes EnsureImpactData as we may not need to re-fetch.   