### PR TITLE
mrc-1631 Send baseline settings to backend when fetching data

### DIFF
--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/helpers/Settings.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/helpers/Settings.kt
@@ -1,0 +1,15 @@
+package org.imperial.mrc.mint.helpers
+
+class Settings {
+    companion object {
+        val Baseline = mapOf(
+                "levelOfResistance" to "0%",
+                "seasonalityOfTransmission" to "seasonal",
+                "currentPrevalence" to "low",
+                "bitingIndoors" to "high",
+                "bitingPeople" to "low",
+                "itnUsage" to "0%",
+                "sprayInput" to "0%"
+        )
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.imperial.mrc.mint.ConfiguredAppProperties
 import org.imperial.mrc.mint.MintrAPIClient
 import org.imperial.mrc.mint.helpers.JSONValidator
+import org.imperial.mrc.mint.helpers.Settings
 import org.junit.jupiter.api.Test
 
 class MintrAPIClientTests {
@@ -35,7 +36,7 @@ class MintrAPIClientTests {
     @Test
     fun `can get impact graph prevalence data`() {
         val sut = MintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val result = sut.getImpactGraphPrevalenceData(mapOf())
+        val result = sut.getImpactGraphPrevalenceData(Settings.Baseline)
         assertThat(result.statusCodeValue).isEqualTo(200)
         JSONValidator().validateSuccess(result.body!!, "Data")
     }
@@ -51,7 +52,7 @@ class MintrAPIClientTests {
     @Test
     fun `can get impact table data`() {
         val sut = MintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val result = sut.getImpactTableData(mapOf())
+        val result = sut.getImpactTableData(Settings.Baseline)
         assertThat(result.statusCodeValue).isEqualTo(200)
         JSONValidator().validateSuccess(result.body!!, "Data")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/ImpactTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/ImpactTests.kt
@@ -1,5 +1,6 @@
 package org.imperial.mrc.mint.integration.endpoints
 
+import org.imperial.mrc.mint.helpers.Settings
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.boot.test.web.client.postForEntity
@@ -14,7 +15,7 @@ class ImpactTests: EndpointTests() {
     @Test
     fun `can get impact graph prevalence data`() {
         val responseEntity = testRestTemplate.postForEntity<String>("/impact/graph/prevalence/data",
-                mapOf<String, Any>())
+                Settings.Baseline)
         assertSuccess(responseEntity, "Data")
     }
 
@@ -27,7 +28,7 @@ class ImpactTests: EndpointTests() {
     @Test
     fun `can get impact table data`() {
         val responseEntity = testRestTemplate.postForEntity<String>("/impact/table/data",
-                mapOf<String, Any>())
+                Settings.Baseline)
         assertSuccess(responseEntity, "Data")
     }
 }

--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -23,7 +23,7 @@ export enum RootAction {
 }
 
 const currentRegionBaseline = (state: RootState) => {
-    return state.currentProject!!.currentRegion.baselineOptions;
+    return state.currentProject!!.currentRegion.baselineSettings;
 };
 
 const currentRegionInterventions = (state: RootState) => {

--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -3,14 +3,14 @@
         <dynamic-form v-model="options"
                       :include-submit-button="true"
                       submit-text="Next"
-                      @submit="$emit('submit')"
+                      @submit="submit"
                       @validate="$emit('validate', $event)"
                     ></dynamic-form>
     </div>
 </template>
 <script lang="ts">
     import Vue from "vue";
-    import {DynamicForm, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+    import {DynamicForm, DynamicFormMeta, DynamicFormData} from "@reside-ic/vue-dynamic-form";
     import {Project} from "../models/project";
     import {mapState} from "vuex";
     import {mapMutationByName} from "../utils";
@@ -23,12 +23,20 @@
 
     interface Methods {
         update: (value: DynamicFormMeta) => void
+        submit: (settings: DynamicFormData) => void
+        updateBaselineSettings: (settings: DynamicFormData) => void
     }
 
     export default Vue.extend<{}, Methods, Computed, {}>({
         components: {DynamicForm},
         methods: {
-            update: mapMutationByName(RootMutation.SetCurrentRegionBaselineOptions)
+            submit: function(settings: DynamicFormData) {
+                alert("settings: " + JSON.stringify(settings));
+                this.updateBaselineSettings(settings);
+                this.$emit('submit');
+            },
+            update: mapMutationByName(RootMutation.SetCurrentRegionBaselineOptions),
+            updateBaselineSettings: mapMutationByName(RootMutation.SetCurrentRegionBaselineSettings)
         },
         computed: {
             ...mapState(["currentProject"]),

--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -31,7 +31,6 @@
         components: {DynamicForm},
         methods: {
             submit: function(settings: DynamicFormData) {
-                alert("settings: " + JSON.stringify(settings));
                 this.updateBaselineSettings(settings);
                 this.$emit('submit');
             },

--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -4,8 +4,7 @@
                       :include-submit-button="true"
                       submit-text="Next"
                       @submit="submit"
-                      @validate="$emit('validate', $event)"
-                    ></dynamic-form>
+                      @validate="$emit('validate', $event)" ></dynamic-form>
     </div>
 </template>
 <script lang="ts">

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -6,6 +6,7 @@ export interface Region {
     name: string
     url: string
     baselineOptions: DynamicFormMeta
+    baselineSettings: DynamicFormData
     interventionOptions: DynamicFormMeta
     interventionSettings: DynamicFormData
     prevalenceGraphData: Data
@@ -23,8 +24,9 @@ export class Region {
         this.name = name;
         this.url = `/projects/${parent.name}/regions/${name}`.replace(/\s/g, "-").toLowerCase();
         this.baselineOptions = deepCopy(baselineOptions);
+        this.baselineSettings = {};
         this.interventionOptions = deepCopy(interventionOptions);
-        this.interventionSettings =  {}
+        this.interventionSettings =  {};
         this.interventionOptions.controlSections.map(s => {
             s.controlGroups.map(g => {
                 g.controls.map(c => {

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -9,6 +9,7 @@ export enum RootMutation {
     AddProject = "AddProject",
     SetCurrentRegion = "SetCurrentRegion",
     SetCurrentRegionBaselineOptions = "SetCurrentRegionBaselineOptions",
+    SetCurrentRegionBaselineSettings = "SetCurrentRegionBaselineSettings",
     SetCurrentRegionInterventionOptions = "SetCurrentRegionInterventionOptions",
     SetCurrentRegionInterventionSettings = "SetCurrentRegionInterventionSettings",
     SetCurrentRegionStep = "SetCurrentRegionStep",
@@ -51,6 +52,12 @@ export const mutations: MutationTree<RootState> = {
                                                        payload: DynamicFormMeta) {
         if (state.currentProject) {
             state.currentProject.currentRegion.interventionOptions = payload
+        }
+    },
+
+    [RootMutation.SetCurrentRegionBaselineSettings](state: RootState, payload: DynamicFormData) {
+        if (state.currentProject) {
+            state.currentProject.currentRegion.baselineSettings = payload;
         }
     },
 

--- a/src/app/static/src/tests/components/baseline.test.ts
+++ b/src/app/static/src/tests/components/baseline.test.ts
@@ -16,13 +16,15 @@ describe("baseline", () => {
             { label: "section3", controlGroups: [] }
         ]
     };
-    const getWrapper = (setBaselineMock = jest.fn()) => {
+    const getWrapper = (setBaselineMock = jest.fn(), setBaselineSettingsMock = jest.fn()) => {
+        const currentProject = new Project("project 1", ["region 1"], baselineOptions, {controlSections: []});
         const store =  new Vuex.Store({
             state: mockRootState({
-                currentProject: new Project("project 1", ["region 1"], baselineOptions, {controlSections: []})
+                currentProject
             }),
             mutations: {
-                [RootMutation.SetCurrentRegionBaselineOptions]: setBaselineMock
+                [RootMutation.SetCurrentRegionBaselineOptions]: setBaselineMock,
+                [RootMutation.SetCurrentRegionBaselineSettings]: setBaselineSettingsMock
             }
         });
 
@@ -48,12 +50,16 @@ describe("baseline", () => {
         expect(mockMutation.mock.calls[0][1][0]).toBe(newBaseline);
     });
 
-    it("emits submit event when form is submitted", async () => {
-        const wrapper = getWrapper();
-        wrapper.find(DynamicForm).vm.$emit("submit");
+    it("commits update baseline settings and emits submit event when form is submitted", async () => {
+        const mockSetBaselineSettings = jest.fn();
+        const wrapper = getWrapper(jest.fn(), mockSetBaselineSettings);
+        const mockSettings = {population: 1000};
+        wrapper.find(DynamicForm).vm.$emit("submit", mockSettings);
 
         await Vue.nextTick();
         expect(wrapper.emitted("submit")!!.length).toBe(1);
+        expect(mockSetBaselineSettings.mock.calls.length).toBe(1);
+        expect(mockSetBaselineSettings.mock.calls[0][1]).toBe(mockSettings);
     });
 
     it("emits validate event when form is validated", async () => {

--- a/src/app/static/src/tests/components/interventions.test.ts
+++ b/src/app/static/src/tests/components/interventions.test.ts
@@ -189,6 +189,7 @@ describe("interventions", () => {
                 name: "newRegion",
                 url: "/",
                 baselineOptions: {controlSections: []},
+                baselineSettings: {},
                 interventionOptions: {controlSections: []},
                 interventionSettings: {},
                 impactTableData: [],

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -103,6 +103,7 @@ describe("project page", () => {
             regions: [{
                 name: "South", url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
+                baselineSettings: {},
                 interventionOptions: mockInterventionOptions,
                 interventionSettings: {"c1": null},
                 prevalenceGraphData: [],
@@ -114,6 +115,7 @@ describe("project page", () => {
             currentRegion: {
                 name: "South", url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
+                baselineSettings: {},
                 interventionOptions: mockInterventionOptions,
                 interventionSettings: {"c1": null},
                 prevalenceGraphData: [],
@@ -155,6 +157,7 @@ describe("project page", () => {
                 name: "South",
                 url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
+                baselineSettings: {},
                 interventionOptions: mockInterventionOptions,
                 interventionSettings: {"c1": null},
                 prevalenceGraphData: [],
@@ -167,6 +170,7 @@ describe("project page", () => {
                 name: "South",
                 url: "/projects/new-project/regions/south",
                 baselineOptions: mockBaselineOptions,
+                baselineSettings: {},
                 interventionOptions: mockInterventionOptions,
                 interventionSettings: {"c1": null},
                 prevalenceGraphData: [],

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -6,14 +6,20 @@ describe("actions", () => {
 
     const getStateWithBaselineSettings = async () => {
         const commit = jest.fn();
-        await (actions[RootAction.FetchPrevalenceGraphConfig] as any)({commit} as any);
+        await (actions[RootAction.FetchBaselineOptions] as any)({commit} as any);
         const options = commit.mock.calls[0][1] as DynamicFormMeta;
-        const settings = {};
-        settings.forEach
+        const settings = {} as any;
+        options.controlSections.forEach((section) => {
+            section.controlGroups.forEach((group) => {
+                group.controls.forEach((control) => {
+                    settings[control.name] = control.value
+                });
+            });
+        });
         return {
             currentProject: {
                 currentRegion: {
-                    baselineOptions: options
+                    baselineSettings: settings
                 }
             }
         };
@@ -29,9 +35,10 @@ describe("actions", () => {
         expect(Object.keys(firstRow).sort())
             .toEqual([
                 "intervention",
-                "irs_use",
+                "irsUse",
                 "month",
-                "net_use",
+                "netType",
+                "netUse",
                 "value"]);
     });
 

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -4,10 +4,12 @@ import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("actions", () => {
 
-    const getStateWithBaselineOptions = async () => {
+    const getStateWithBaselineSettings = async () => {
         const commit = jest.fn();
         await (actions[RootAction.FetchPrevalenceGraphConfig] as any)({commit} as any);
         const options = commit.mock.calls[0][1] as DynamicFormMeta;
+        const settings = {};
+        settings.forEach
         return {
             currentProject: {
                 currentRegion: {
@@ -19,7 +21,7 @@ describe("actions", () => {
 
     it("can get prevalence graph data", async () => {
         const commit = jest.fn();
-        const state = await getStateWithBaselineOptions();
+        const state = await getStateWithBaselineSettings();
         await (actions[RootAction.FetchPrevalenceGraphData] as any)({commit, state} as any);
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddPrevalenceGraphData);
@@ -44,7 +46,7 @@ describe("actions", () => {
 
     it("can get cost graph data", async () => {
         const commit = jest.fn();
-        const state = await getStateWithBaselineOptions();
+        const state = await getStateWithBaselineSettings();
         await (actions[RootAction.FetchCostGraphData] as any)({commit, state} as any);
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostGraphData);
@@ -102,7 +104,7 @@ describe("actions", () => {
 
     it("can get impact table data", async () => {
         const commit = jest.fn();
-        const state = await getStateWithBaselineOptions();
+        const state = await getStateWithBaselineSettings();
         await (actions[RootAction.FetchImpactTableData] as any)({commit, state} as any);
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddImpactTableData);
@@ -135,7 +137,7 @@ describe("actions", () => {
 
     it("can get cost table data", async () => {
         const commit = jest.fn();
-        const state = await getStateWithBaselineOptions();
+        const state = await getStateWithBaselineSettings();
         await (actions[RootAction.FetchCostTableData] as any)({commit, state} as any);
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostTableData);

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -17,12 +17,8 @@ describe("actions", () => {
         (console.log as jest.Mock).mockClear();
     });
 
-    const baselineOptions: BaselineOptions = {
-        controlSections:
-            [{
-                label: "section",
-                controlGroups: []
-            }]
+    const baselineSettings: DynamicFormData = {
+        population: 1000
     };
 
     const interventionSettings: DynamicFormData = {
@@ -33,7 +29,8 @@ describe("actions", () => {
     const state = {
         currentProject: {
             currentRegion: {
-                baselineOptions,
+                baselineOptions: [],
+                baselineSettings,
                 interventionSettings,
                 prevalenceGraphData: [],
                 impactTableData: [],
@@ -90,14 +87,14 @@ describe("actions", () => {
 
     it("fetches prevalence graph data", async () => {
         const url = "/impact/graph/prevalence/data";
-        mockAxios.onPost(url, baselineOptions)
+        mockAxios.onPost(url, baselineSettings)
             .reply(200, mockSuccess([{prev: 1, net_use: 0.2, resistance: "low"}]));
 
         const commit = jest.fn();
         await (actions[RootAction.FetchPrevalenceGraphData] as any)({commit, state} as any);
 
         expect(mockAxios.history.post[0].url).toBe(url);
-        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineOptions));
+        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineSettings));
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddPrevalenceGraphData);
         expectEqualsFrozen(commit.mock.calls[0][1], [{prev: 1, net_use: 0.2, resistance: "low"}]);
@@ -116,14 +113,14 @@ describe("actions", () => {
 
     it("fetches impact table data", async () => {
         const url = "/impact/table/data";
-        mockAxios.onPost(url, baselineOptions)
+        mockAxios.onPost(url, baselineSettings)
                 .reply(200, mockSuccess([{prev: 1, net_use: 0.2, resistance: "low"}]));
 
         const commit = jest.fn();
         await (actions[RootAction.FetchImpactTableData] as any)({commit, state} as any);
 
         expect(mockAxios.history.post[0].url).toBe(url);
-        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineOptions));
+        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineSettings));
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddImpactTableData);
         expectEqualsFrozen(commit.mock.calls[0][1], [{prev: 1, net_use: 0.2, resistance: "low"}]);
@@ -143,14 +140,14 @@ describe("actions", () => {
     it("fetches cost table data", async () => {
         const url = "/cost/table/data";
         const testData = [{prev: 1, net_use: 0.2, resistance: "low"}];
-        mockAxios.onPost(url, baselineOptions)
+        mockAxios.onPost(url, baselineSettings)
             .reply(200, mockSuccess(testData));
 
         const commit = jest.fn();
         await (actions[RootAction.FetchCostTableData] as any)({commit, state} as any);
 
         expect(mockAxios.history.post[0].url).toBe(url);
-        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineOptions));
+        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(baselineSettings));
 
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostTableData);
         expectEqualsFrozen(commit.mock.calls[0][1], testData);
@@ -224,7 +221,7 @@ describe("actions", () => {
     it("fetches cost graph data", async () => {
         const url = "/cost/graph/data";
         const testData = [{cases_averted: 1, cost: 10}];
-        const expectedSettings = {...baselineOptions, ...interventionSettings};
+        const expectedSettings = {...baselineSettings, ...interventionSettings};
         mockAxios.onPost(url, expectedSettings)
             .reply(200, mockSuccess(testData));
 
@@ -253,14 +250,14 @@ describe("actions", () => {
         const stateWithoutImpactGraph = {
             currentProject: {
                 currentRegion: {
-                    baselineOptions: baselineOptions,
+                    baselineSettings,
                     prevalenceGraphData: [],
                     impactTableData: ["TEST TABLE DATA"] as any
                 }
             }
         };
         await (actions[RootAction.EnsureImpactData] as any)({dispatch, state: stateWithoutImpactGraph} as any);
-
+        baselineSettings
         expect(dispatch.mock.calls[0][0]).toBe(RootAction.FetchPrevalenceGraphData);
         expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchImpactTableData);
     });
@@ -270,7 +267,7 @@ describe("actions", () => {
         const stateWithoutImpactTable = {
             currentProject: {
                 currentRegion: {
-                    baselineOptions: baselineOptions,
+                    baselineSettings,
                     prevalenceGraphData: ["TEST GRAPH DATA"] as any,
                     impactTableData: []
                 }
@@ -288,7 +285,7 @@ describe("actions", () => {
         const stateWithAllImpactData = {
             currentProject: {
                 currentRegion: {
-                    baselineOptions: baselineOptions,
+                    baselineSettings,
                     prevalenceGraphData: ["TEST GRAPH DATA"] as any,
                     impactTableData: ["TEST TABLE DATA"] as any
                 }
@@ -312,7 +309,7 @@ describe("actions", () => {
         const stateWithCostData = {
             currentProject: {
                 currentRegion: {
-                    baselineOptions: baselineOptions,
+                    baselineSettings,
                     costGraphData: ["TEST COST DATA"]
                 }
             }

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -34,6 +34,7 @@ describe("mutations", () => {
             name: "South region",
             url: "/projects/my-project/regions/south-region",
             baselineOptions: {controlSections: []},
+            baselineSettings: {},
             interventionOptions: {controlSections:[]},
             interventionSettings: {},
             prevalenceGraphData: [],

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -235,4 +235,23 @@ describe("mutations", () => {
         mutations[RootMutation.SetCurrentRegionInterventionSettings](state, newSettings);
         expect(state.currentProject).toBeNull();
     });
+
+    it("updates the current region's baseline settings", () => {
+        const state = mockRootState({
+            currentProject: new Project("my project", ["North region", "South region"],
+                {controlSections: []}, {controlSections: []})
+        });
+
+        const newSettings: DynamicFormData = {"c1": 3};
+        mutations[RootMutation.SetCurrentRegionBaselineSettings](state, newSettings);
+        expect(state.currentProject!!.currentRegion.baselineSettings)
+            .toEqual(newSettings);
+    });
+
+    it("updating the current region's baseline settings does nothing if no current project", () => {
+        const state = mockRootState();
+        const newSettings: DynamicFormData = {"c1": 3};
+        mutations[RootMutation.SetCurrentRegionBaselineSettings](state, newSettings);
+        expect(state.currentProject).toBeNull();
+    });
 });


### PR DESCRIPTION
Use the DynamicFormData containing expected baseline settings rather than the DynamicFormMeta - follows the same pattern we already use for intervention settings.
This prevents the newly updated mintr endpoint for the prevalence graph data from returning an error - although mint still cannot show the graph data - to be fixed in another ticket. 