### PR TITLE
mrc-1942 bug fix - actually submit baseline settings when navigating to step 2

### DIFF
--- a/src/app/static/src/app/components/baseline.vue
+++ b/src/app/static/src/app/components/baseline.vue
@@ -1,10 +1,11 @@
 <template>
     <div class="baseline">
         <dynamic-form v-model="options"
+                      ref="form"
                       :include-submit-button="true"
                       submit-text="Next"
                       @submit="submit"
-                      @validate="$emit('validate', $event)" ></dynamic-form>
+                      @validate="$emit('validate', $event)"></dynamic-form>
     </div>
 </template>
 <script lang="ts">

--- a/src/app/static/src/app/components/regionPage.vue
+++ b/src/app/static/src/app/components/regionPage.vue
@@ -13,9 +13,12 @@
                          text="Explore interventions"
                          :active="currentStep === 2"
                          :disabled="interventionsDisabled"
-                         @click="setCurrentStep(2)"></step-button>
+                         @click="next"></step-button>
         </div>
-        <baseline v-if="currentStep === 1" @submit="setCurrentStep(2)" @validate="baselineValidated"></baseline>
+        <baseline v-if="currentStep === 1"
+                  @submit="setCurrentStep(2)"
+                  @validate="baselineValidated"
+                  ref="baseline"></baseline>
         <interventions v-if="currentStep === 2"></interventions>
     </div>
 </template>
@@ -37,9 +40,10 @@
     }
 
     interface Methods {
-        setCurrentRegion: (params: {project: string, region: string}) => void,
+        setCurrentRegion: (params: { project: string, region: string }) => void,
         setCurrentStep: (step: number) => void,
         baselineValidated: (value: boolean) => void
+        next: () => void;
     }
 
     interface Computed {
@@ -65,6 +69,9 @@
             setCurrentStep: mapMutationByName(RootMutation.SetCurrentRegionStep),
             baselineValidated: function (valid: Boolean) {
                 this.interventionsDisabled = !valid;
+            },
+            next() {
+                ((this.$refs['baseline'] as Vue).$refs["form"] as any).submit();
             }
         },
         watch: {

--- a/src/app/static/src/tests/components/regionPage.test.ts
+++ b/src/app/static/src/tests/components/regionPage.test.ts
@@ -17,13 +17,17 @@ describe("region page", () => {
     localVue.use(VueRouter);
     const router = new VueRouter({routes: [{path: '/projects/:project/regions/:region', component: regionPage}]});
 
-    const createStore = (setCurrentRegionMock = jest.fn(), setCurrentRegionStepMock = jest.fn(), project = mockProject()) => {
+    const createStore = (setCurrentRegionMock = jest.fn(),
+                         setCurrentRegionStepMock = jest.fn(),
+                         project = mockProject(),
+                         setBaselineSettingsMock = jest.fn()) => {
         return new Vuex.Store({
             state: mockRootState({
                 currentProject: project
             }),
             mutations: {
-                [RootMutation.SetCurrentRegionStep]: setCurrentRegionStepMock
+                [RootMutation.SetCurrentRegionStep]: setCurrentRegionStepMock,
+                [RootMutation.SetCurrentRegionBaselineSettings]: setBaselineSettingsMock
             },
             actions: {
                 [RootAction.SetCurrentRegion]: setCurrentRegionMock
@@ -75,7 +79,7 @@ describe("region page", () => {
         expect(setCurrentRegionMock.mock.calls[1][1]).toEqual({project: "new-project", region: "new-region"});
     });
 
-    it("sets current step when step is clicked", async () => {
+    it("sets current step to 1 when step 1 is clicked", async () => {
         const mockSetRegionStep = jest.fn();
         const store = createStore(jest.fn(), mockSetRegionStep);
         const wrapper = mount(regionPage, {localVue, store, router});
@@ -94,7 +98,22 @@ describe("region page", () => {
 
         expect(mockSetRegionStep.mock.calls.length).toBe(2);
         expect(mockSetRegionStep.mock.calls[1][1]).toBe(1);
+    });
 
+    it("saves baseline settings and sets current step to 2 when step 2 is clicked", async () => {
+        const mockSetRegionStep = jest.fn();
+        const mockSetBaselineSettings = jest.fn();
+        const store = createStore(jest.fn(), mockSetRegionStep, mockProject(), mockSetBaselineSettings);
+        const wrapper = mount(regionPage, {localVue, store, router});
+
+        const buttons = wrapper.findAll("button");
+        buttons.at(1).trigger("click");
+
+        await Vue.nextTick();
+
+        expect(mockSetBaselineSettings.mock.calls.length).toBe(1);
+        expect(mockSetRegionStep.mock.calls.length).toBe(1);
+        expect(mockSetRegionStep.mock.calls[0][1]).toBe(2);
     });
 
     it("sets current step to 2 when baseline is submitted", async () => {


### PR DESCRIPTION
Fixes a bug whereby clicking on the step 2 icon navigates to step 2 without saving the baseline settings, resulting in errors with the figures.