### PR TITLE
mrc-1997 npm audit fix and fix tests

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -2716,27 +2716,6 @@
         "vue": "^2.6.10"
       }
     },
-    "@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
-      "dev": true,
-      "requires": {
-        "wgs84": "0.0.0"
-      }
-    },
-    "@mapbox/geojson-rewind": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
-      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
-      "dev": true,
-      "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "^1.2.5",
-        "sharkdown": "^0.1.0"
-      }
-    },
     "@mapbox/geojson-types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
@@ -2846,6 +2825,24 @@
         "d3-collection": "^1.0.4",
         "d3-shape": "^1.2.0",
         "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "dev": true,
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "@reside-ic/vue-dynamic-form": {
@@ -3394,12 +3391,6 @@
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
-    },
     "acorn-globals": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
@@ -3417,12 +3408,6 @@
           "dev": true
         }
       }
-    },
-    "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "dev": true
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -3489,17 +3474,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
     },
     "almost-equal": {
       "version": "1.1.0",
@@ -3579,12 +3553,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
     "any-promise": {
@@ -4384,9 +4352,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
@@ -4616,45 +4584,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buble": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
-      "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
-      "dev": true,
-      "requires": {
-        "acorn": "^6.1.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.0.1",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.3",
-        "minimist": "^1.2.0",
-        "os-homedir": "^2.0.0",
-        "regexpu-core": "^4.5.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-          "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
-          "dev": true
-        }
-      }
-    },
-    "bubleify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.1.tgz",
-      "integrity": "sha512-vp3NHmaQVoKaKWvi15FTMinPNjfp+47+/kFJ9ifezdMF/CBLArCxDVUh+FQE3qRxCRj1qyjJqilTBHHqlM8MaQ==",
-      "dev": true,
-      "requires": {
-        "buble": "^0.19.3"
-      }
-    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -4823,16 +4752,6 @@
         "rsvp": "^4.8.4"
       }
     },
-    "cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
-      }
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -4855,16 +4774,6 @@
       "resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
       "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA=",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -5681,60 +5590,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "cwise": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
-      "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
-      "dev": true,
-      "requires": {
-        "cwise-compiler": "^1.1.1",
-        "cwise-parser": "^1.0.0",
-        "static-module": "^1.0.0",
-        "uglify-js": "^2.6.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          }
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
     "cwise-compiler": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
@@ -5742,24 +5597,6 @@
       "dev": true,
       "requires": {
         "uniq": "^1.0.0"
-      }
-    },
-    "cwise-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
-      "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
-      "dev": true,
-      "requires": {
-        "esprima": "^1.0.3",
-        "uniq": "^1.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
-          "dev": true
-        }
       }
     },
     "cyclist": {
@@ -5854,6 +5691,21 @@
       "dev": true,
       "requires": {
         "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "dev": true
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dev": true,
+      "requires": {
+        "d3-time": "1"
       }
     },
     "d3-timer": {
@@ -6272,41 +6124,6 @@
       "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk=",
       "dev": true
     },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.9"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -6394,9 +6211,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -6515,12 +6332,6 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -7690,8 +7501,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7712,14 +7522,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7734,20 +7542,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7864,8 +7669,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7877,7 +7681,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7892,7 +7695,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7900,14 +7702,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7926,7 +7726,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -7988,8 +7787,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8017,8 +7815,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8030,7 +7827,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8108,8 +7904,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8145,7 +7940,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8165,7 +7959,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8209,14 +8002,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8444,42 +8235,6 @@
         "sprintf-js": "^1.0.3"
       }
     },
-    "gl-heatmap2d": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.6.tgz",
-      "integrity": "sha512-+agzSv4R5vsaH+AGYVz5RVzBK10amqAa+Bwj205F13JjNSGS91M1L9Yb8zssCv2FIjpP+1Mp73cFBYrQFfS1Jg==",
-      "dev": true,
-      "requires": {
-        "binary-search-bounds": "^2.0.4",
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.2.1",
-        "glslify": "^7.0.0",
-        "iota-array": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
-      }
-    },
-    "gl-line3d": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.0.tgz",
-      "integrity": "sha512-du9GDF87DMfllND2pBjySyHhFaza9upw4t2GMoXn11/I38atO6+saiznuhKmfxuDnyxGdmmZF6/HPauk0owKDA==",
-      "dev": true,
-      "requires": {
-        "binary-search-bounds": "^2.0.4",
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.1.0",
-        "gl-vao": "^1.3.0",
-        "glsl-out-of-range": "^1.0.4",
-        "glslify": "^7.0.0",
-        "ndarray": "^1.0.18"
-      }
-    },
-    "gl-mat2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gl-mat2/-/gl-mat2-1.0.1.tgz",
-      "integrity": "sha1-FCUFcwpcL+Hp8l2ezj0NbMJxCjA=",
-      "dev": true
-    },
     "gl-mat3": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
@@ -8497,17 +8252,6 @@
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
       "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==",
       "dev": true
-    },
-    "gl-matrix-invert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
-      "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
-      "dev": true,
-      "requires": {
-        "gl-mat2": "^1.0.0",
-        "gl-mat3": "^1.0.0",
-        "gl-mat4": "^1.0.0"
-      }
     },
     "gl-mesh3d": {
       "version": "2.3.1",
@@ -8530,45 +8274,6 @@
         "polytope-closest-point": "^1.0.0",
         "simplicial-complex-contour": "^1.0.2",
         "typedarray-pool": "^1.1.0"
-      }
-    },
-    "gl-plot2d": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.4.tgz",
-      "integrity": "sha512-0UhKiiqeampLtydv6NMNrKEilc0Ui5oaJtvHLbLZ5u/1ttT1XjOY5Yk8LzfqozA/No4a9omxjSKnH+tvSn+rQQ==",
-      "dev": true,
-      "requires": {
-        "binary-search-bounds": "^2.0.4",
-        "gl-buffer": "^2.1.2",
-        "gl-select-static": "^2.0.6",
-        "gl-shader": "^4.2.1",
-        "glsl-inverse": "^1.0.0",
-        "glslify": "^7.0.0",
-        "text-cache": "^4.2.2"
-      }
-    },
-    "gl-plot3d": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.5.tgz",
-      "integrity": "sha512-cKAqMXFRHTCFxH8r1/ACdk5hyfnA9djfiAM8zVQrqu0qLEttUu0i1fq0pr+d5m0HPuNcK8wEc4F3VjL2hrDcGQ==",
-      "dev": true,
-      "requires": {
-        "3d-view": "^2.0.0",
-        "a-big-triangle": "^1.0.3",
-        "gl-axes3d": "^1.5.3",
-        "gl-fbo": "^2.0.5",
-        "gl-mat4": "^1.2.0",
-        "gl-select-static": "^2.0.6",
-        "gl-shader": "^4.2.1",
-        "gl-spikes3d": "^1.0.10",
-        "glslify": "^7.0.0",
-        "has-passive-events": "^1.0.0",
-        "is-mobile": "^2.2.1",
-        "mouse-change": "^1.4.0",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.2.0",
-        "ndarray": "^1.0.18",
-        "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
@@ -8622,19 +8327,6 @@
         "glslify": "^7.0.0"
       }
     },
-    "gl-select-static": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.6.tgz",
-      "integrity": "sha512-p4DmBG1DMo/47/fV3oqPcU6uTqHy0eI1vATH1fm8OVDqlzWnLv3786tdEunZWG6Br7DUdH6NgWhuy4gAlt+TAQ==",
-      "dev": true,
-      "requires": {
-        "bit-twiddle": "^1.0.2",
-        "cwise": "^1.0.10",
-        "gl-fbo": "^2.0.5",
-        "ndarray": "^1.0.18",
-        "typedarray-pool": "^1.1.0"
-      }
-    },
     "gl-shader": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
@@ -8685,33 +8377,6 @@
         "glsl-out-of-range": "^1.0.4",
         "glsl-specular-cook-torrance": "^2.0.1",
         "glslify": "^7.0.0"
-      }
-    },
-    "gl-surface3d": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.5.2.tgz",
-      "integrity": "sha512-rWSQwEQDkB0T5CDEDFJwJc4VgwwJaAyFRSJ92NJlrTSwDlsEsWdzG9+APx6FWJMwkOpIoZGWqv+csswK2kMMLQ==",
-      "dev": true,
-      "requires": {
-        "binary-search-bounds": "^2.0.4",
-        "bit-twiddle": "^1.0.2",
-        "colormap": "^2.3.1",
-        "dup": "^1.0.0",
-        "gl-buffer": "^2.1.2",
-        "gl-mat4": "^1.2.0",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.1.0",
-        "gl-vao": "^1.3.0",
-        "glsl-out-of-range": "^1.0.4",
-        "glsl-specular-beckmann": "^1.1.2",
-        "glslify": "^7.0.0",
-        "ndarray": "^1.0.18",
-        "ndarray-gradient": "^1.0.0",
-        "ndarray-ops": "^1.2.2",
-        "ndarray-pack": "^1.2.1",
-        "ndarray-scratch": "^1.2.0",
-        "surface-nets": "^1.0.2",
-        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-text": {
@@ -9784,6 +9449,12 @@
         "quantize": "^1.0.2"
       }
     },
+    "image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -10137,12 +9808,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
       "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY=",
-      "dev": true
-    },
-    "is-mobile": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.1.tgz",
-      "integrity": "sha512-6zELsfVFr326eq2CI53yvqq6YBanOxKBybwDT+MbMS2laBnK6Ez8m5XHSuTQQbnKRfpDzCod1CMWW5q3wZYMvA==",
       "dev": true
     },
     "is-negated-glob": {
@@ -10948,8 +10613,7 @@
         },
         "yargs-parser": {
           "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -14339,9 +14003,9 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -15327,9 +14991,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
     "js-base64": {
@@ -15548,12 +15212,6 @@
         "es6-weak-map": "^2.0.1"
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -15580,12 +15238,6 @@
       "requires": {
         "flush-write-stream": "^1.0.2"
       }
-    },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-      "dev": true
     },
     "lerp": {
       "version": "1.0.3",
@@ -15693,9 +15345,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -15730,12 +15382,6 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -15779,15 +15425,6 @@
       "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -15880,45 +15517,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "mapbox-gl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.2.tgz",
-      "integrity": "sha512-6Ro7GbTMWxcbc836m6rbBNkesgTncbE1yXWeuHlr89esSqaItKr0+ntOu8rZie3fv+GtitkbODysXzIGCA7G+w==",
-      "dev": true,
-      "requires": {
-        "@mapbox/geojson-rewind": "^0.4.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
-        "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.0.5",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
-        "tinyqueue": "^2.0.0",
-        "vt-pbf": "^3.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
       }
     },
     "marching-simplex-table": {
@@ -16562,15 +16160,6 @@
         "typedarray-pool": "^1.0.0"
       }
     },
-    "ndarray-fill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
-      "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
-      "dev": true,
-      "requires": {
-        "cwise": "^1.0.10"
-      }
-    },
     "ndarray-gradient": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
@@ -16579,16 +16168,6 @@
       "requires": {
         "cwise-compiler": "^1.0.0",
         "dup": "^1.0.0"
-      }
-    },
-    "ndarray-homography": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
-      "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
-      "dev": true,
-      "requires": {
-        "gl-matrix-invert": "^1.0.0",
-        "ndarray-warp": "^1.0.0"
       }
     },
     "ndarray-linear-interpolate": {
@@ -16634,16 +16213,6 @@
       "dev": true,
       "requires": {
         "typedarray-pool": "^1.0.0"
-      }
-    },
-    "ndarray-warp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
-      "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
-      "dev": true,
-      "requires": {
-        "cwise": "^1.0.4",
-        "ndarray-linear-interpolate": "^1.0.0"
       }
     },
     "neo-async": {
@@ -16693,9 +16262,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-gyp": {
@@ -17625,74 +17194,419 @@
       }
     },
     "plotly.js": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.53.0.tgz",
-      "integrity": "sha512-pNZNdwJs9Qdm/gti9blVA9Io4OfDktatT4k7yBDT+oH/JDbDu9p4/M/15o83qla+ecZx2d5rwOEt9vuytBMhFA==",
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.57.1.tgz",
+      "integrity": "sha512-23GlzClmOGT1lE86Ys0DLuxBM/fgRNzJqH9y7ZylO4VPwstPAlQd12DklXsuqOgCNSxnnWUaP+J7BaUOFplsUg==",
       "dev": true,
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/point-cluster": "^3.1.9",
         "@turf/area": "^6.0.1",
         "@turf/bbox": "^6.0.1",
         "@turf/centroid": "^6.0.2",
         "alpha-shape": "^1.0.0",
         "canvas-fit": "^1.5.0",
-        "color-normalize": "^1.5.0",
-        "color-rgba": "^2.1.1",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
         "convex-hull": "^1.0.3",
         "country-regex": "^1.1.0",
-        "d3": "^3.5.12",
-        "d3-force": "^1.0.6",
+        "d3": "^3.5.17",
+        "d3-force": "^1.2.1",
         "d3-hierarchy": "^1.1.9",
         "d3-interpolate": "^1.4.0",
+        "d3-time-format": "^2.2.3",
         "delaunay-triangulate": "^1.1.6",
-        "es6-promise": "^3.0.2",
-        "fast-isnumeric": "^1.1.3",
-        "gl-cone3d": "^1.5.1",
-        "gl-contour2d": "^1.1.6",
-        "gl-error3d": "^1.0.15",
-        "gl-heatmap2d": "^1.0.5",
-        "gl-line3d": "1.2.0",
+        "es6-promise": "^4.2.8",
+        "fast-isnumeric": "^1.1.4",
+        "gl-cone3d": "^1.5.2",
+        "gl-contour2d": "^1.1.7",
+        "gl-error3d": "^1.0.16",
+        "gl-heatmap2d": "^1.1.0",
+        "gl-line3d": "1.2.1",
         "gl-mat4": "^1.2.0",
-        "gl-mesh3d": "^2.3.0",
-        "gl-plot2d": "^1.4.3",
-        "gl-plot3d": "^2.4.4",
-        "gl-pointcloud2d": "^1.0.2",
-        "gl-scatter3d": "^1.2.2",
-        "gl-select-box": "^1.0.3",
+        "gl-mesh3d": "^2.3.1",
+        "gl-plot2d": "^1.4.5",
+        "gl-plot3d": "^2.4.6",
+        "gl-pointcloud2d": "^1.0.3",
+        "gl-scatter3d": "^1.2.3",
+        "gl-select-box": "^1.0.4",
         "gl-spikes2d": "^1.0.2",
-        "gl-streamtube3d": "^1.4.0",
-        "gl-surface3d": "^1.5.1",
+        "gl-streamtube3d": "^1.4.1",
+        "gl-surface3d": "^1.6.0",
         "gl-text": "^1.1.8",
-        "glslify": "^7.0.0",
+        "glslify": "^7.1.1",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
-        "is-mobile": "^2.2.0",
-        "mapbox-gl": "1.3.2",
+        "image-size": "^0.7.5",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
         "matrix-camera-controller": "^2.1.3",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
-        "ndarray": "^1.0.18",
-        "ndarray-fill": "^1.0.2",
-        "ndarray-homography": "^1.0.0",
-        "point-cluster": "^3.1.8",
+        "ndarray": "^1.0.19",
+        "ndarray-linear-interpolate": "^1.0.0",
+        "parse-svg-path": "^0.1.2",
         "polybooljs": "^1.2.0",
-        "regl": "^1.3.11",
-        "regl-error2d": "^2.0.8",
-        "regl-line2d": "^3.0.15",
-        "regl-scatter2d": "^3.1.7",
-        "regl-splom": "^1.0.8",
+        "regl": "^1.6.1",
+        "regl-error2d": "^2.0.11",
+        "regl-line2d": "^3.0.18",
+        "regl-scatter2d": "^3.2.1",
+        "regl-splom": "^1.0.12",
         "right-now": "^1.0.0",
         "robust-orientation": "^1.1.3",
         "sane-topojson": "^4.0.0",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
         "svg-path-sdf": "^1.1.3",
-        "tinycolor2": "^1.4.1",
-        "topojson-client": "^2.1.0",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
         "webgl-context": "^2.2.0",
         "world-calendars": "^1.0.3"
+      },
+      "dependencies": {
+        "@mapbox/geojson-rewind": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
+          "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "~2.0.0",
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+              "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+              }
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+          "dev": true
+        },
+        "gl-heatmap2d": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.0.tgz",
+          "integrity": "sha512-0FLXyxv6UBCzzhi4Q2u+9fUs6BX1+r5ZztFe27VikE9FUVw7hZiuSHmgDng92EpydogcSYHXCIK8+58RagODug==",
+          "dev": true,
+          "requires": {
+            "binary-search-bounds": "^2.0.4",
+            "gl-buffer": "^2.1.2",
+            "gl-shader": "^4.2.1",
+            "glslify": "^7.0.0",
+            "iota-array": "^1.0.0",
+            "typedarray-pool": "^1.2.0"
+          }
+        },
+        "gl-line3d": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.1.tgz",
+          "integrity": "sha512-eeb0+RI2ZBRqMYJK85SgsRiJK7c4aiOjcnirxv0830A3jmOc99snY3AbPcV8KvKmW0Yaf3KA4e+qNCbHiTOTnA==",
+          "dev": true,
+          "requires": {
+            "binary-search-bounds": "^2.0.4",
+            "gl-buffer": "^2.1.2",
+            "gl-shader": "^4.2.1",
+            "gl-texture2d": "^2.1.0",
+            "gl-vao": "^1.3.0",
+            "glsl-out-of-range": "^1.0.4",
+            "glslify": "^7.0.0",
+            "ndarray": "^1.0.18"
+          }
+        },
+        "gl-plot2d": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.5.tgz",
+          "integrity": "sha512-6GmCN10SWtV+qHFQ1gjdnVubeHFVsm6P4zmo0HrPIl9TcdePCUHDlBKWAuE6XtFhiMKMj7R8rApOX8O8uXUYog==",
+          "dev": true,
+          "requires": {
+            "binary-search-bounds": "^2.0.4",
+            "gl-buffer": "^2.1.2",
+            "gl-select-static": "^2.0.7",
+            "gl-shader": "^4.2.1",
+            "glsl-inverse": "^1.0.0",
+            "glslify": "^7.0.0",
+            "text-cache": "^4.2.2"
+          }
+        },
+        "gl-plot3d": {
+          "version": "2.4.7",
+          "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.7.tgz",
+          "integrity": "sha512-mLDVWrl4Dj0O0druWyHUK5l7cBQrRIJRn2oROEgrRuOgbbrLAzsREKefwMO0bA0YqkiZMFMnV5VvPA9j57X5Xg==",
+          "dev": true,
+          "requires": {
+            "3d-view": "^2.0.0",
+            "a-big-triangle": "^1.0.3",
+            "gl-axes3d": "^1.5.3",
+            "gl-fbo": "^2.0.5",
+            "gl-mat4": "^1.2.0",
+            "gl-select-static": "^2.0.7",
+            "gl-shader": "^4.2.1",
+            "gl-spikes3d": "^1.0.10",
+            "glslify": "^7.0.0",
+            "has-passive-events": "^1.0.0",
+            "is-mobile": "^2.2.1",
+            "mouse-change": "^1.4.0",
+            "mouse-event-offset": "^3.0.2",
+            "mouse-wheel": "^1.2.0",
+            "ndarray": "^1.0.19",
+            "right-now": "^1.0.0"
+          }
+        },
+        "gl-select-static": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.7.tgz",
+          "integrity": "sha512-OvpYprd+ngl3liEatBTdXhSyNBjwvjMSvV2rN0KHpTU+BTi4viEETXNZXFgGXY37qARs0L28ybk3UQEW6C5Nnw==",
+          "dev": true,
+          "requires": {
+            "bit-twiddle": "^1.0.2",
+            "gl-fbo": "^2.0.5",
+            "ndarray": "^1.0.18",
+            "typedarray-pool": "^1.1.0"
+          }
+        },
+        "gl-surface3d": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.6.0.tgz",
+          "integrity": "sha512-x15+u4712ysnB85G55RLJEml6mOB4VaDn0VTlXCc9JcjRl5Es10Tk7lhGGyiPtkCfHwvhnkxzYA1/rHHYN7Y0A==",
+          "dev": true,
+          "requires": {
+            "binary-search-bounds": "^2.0.4",
+            "bit-twiddle": "^1.0.2",
+            "colormap": "^2.3.1",
+            "dup": "^1.0.0",
+            "gl-buffer": "^2.1.2",
+            "gl-mat4": "^1.2.0",
+            "gl-shader": "^4.2.1",
+            "gl-texture2d": "^2.1.0",
+            "gl-vao": "^1.3.0",
+            "glsl-out-of-range": "^1.0.4",
+            "glsl-specular-beckmann": "^1.1.2",
+            "glslify": "^7.0.0",
+            "ndarray": "^1.0.18",
+            "ndarray-gradient": "^1.0.0",
+            "ndarray-ops": "^1.2.2",
+            "ndarray-pack": "^1.2.1",
+            "ndarray-scratch": "^1.2.0",
+            "surface-nets": "^1.0.2",
+            "typedarray-pool": "^1.1.0"
+          }
+        },
+        "glslify": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+          "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.1",
+            "concat-stream": "^1.5.2",
+            "duplexify": "^3.4.5",
+            "falafel": "^2.1.0",
+            "from2": "^2.3.0",
+            "glsl-resolve": "0.0.1",
+            "glsl-token-whitespace-trim": "^1.0.0",
+            "glslify-bundle": "^5.0.0",
+            "glslify-deps": "^1.2.5",
+            "minimist": "^1.2.5",
+            "resolve": "^1.1.5",
+            "stack-trace": "0.0.9",
+            "static-eval": "^2.0.5",
+            "through2": "^2.0.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "is-mobile": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+          "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg==",
+          "dev": true
+        },
+        "mapbox-gl": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+          "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+          "dev": true,
+          "requires": {
+            "@mapbox/geojson-rewind": "^0.5.0",
+            "@mapbox/geojson-types": "^1.0.2",
+            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+            "@mapbox/mapbox-gl-supported": "^1.5.0",
+            "@mapbox/point-geometry": "^0.1.0",
+            "@mapbox/tiny-sdf": "^1.1.1",
+            "@mapbox/unitbezier": "^0.0.0",
+            "@mapbox/vector-tile": "^1.3.1",
+            "@mapbox/whoots-js": "^3.1.0",
+            "csscolorparser": "~1.0.3",
+            "earcut": "^2.2.2",
+            "geojson-vt": "^3.2.1",
+            "gl-matrix": "^3.2.1",
+            "grid-index": "^1.1.0",
+            "minimist": "^1.2.5",
+            "murmurhash-js": "^1.0.0",
+            "pbf": "^3.2.1",
+            "potpack": "^1.0.1",
+            "quickselect": "^2.0.0",
+            "rw": "^1.3.3",
+            "supercluster": "^7.0.0",
+            "tinyqueue": "^2.0.3",
+            "vt-pbf": "^3.1.1"
+          }
+        },
+        "regl": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+          "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w==",
+          "dev": true
+        },
+        "regl-error2d": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.11.tgz",
+          "integrity": "sha512-Bv4DbLtDU69GXPSm+NvlVWzT82oQ8M2FK+SxzkyaYMlA9izZRdLmDADqBSyJTnPWiRT4a/2KA+MP+WI0N0yt7Q==",
+          "dev": true,
+          "requires": {
+            "array-bounds": "^1.0.1",
+            "color-normalize": "^1.5.0",
+            "flatten-vertex-data": "^1.0.2",
+            "object-assign": "^4.1.1",
+            "pick-by-alias": "^1.2.0",
+            "to-float32": "^1.0.1",
+            "update-diff": "^1.1.0"
+          }
+        },
+        "regl-line2d": {
+          "version": "3.0.18",
+          "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.18.tgz",
+          "integrity": "sha512-yX1TlV0SHBdn8EkU+9K+K19qx7WSDOchrKx+h43rE2NCWuPlVj/MPDgrIXnzhnd42XhQtvvnkSc7aCSLjGAhZQ==",
+          "dev": true,
+          "requires": {
+            "array-bounds": "^1.0.1",
+            "array-normalize": "^1.1.4",
+            "color-normalize": "^1.5.0",
+            "earcut": "^2.1.5",
+            "es6-weak-map": "^2.0.3",
+            "flatten-vertex-data": "^1.0.2",
+            "glslify": "^7.0.0",
+            "object-assign": "^4.1.1",
+            "parse-rect": "^1.2.0",
+            "pick-by-alias": "^1.2.0",
+            "to-float32": "^1.0.1"
+          }
+        },
+        "regl-scatter2d": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.1.tgz",
+          "integrity": "sha512-qxUCK5kXuoVZin2gPLXkgkBfRr3XLobVgEfn5N0fiprsb/ncTCtSNVBqP0EJgNb115R+FXte9LKA9YrFx7uBnA==",
+          "dev": true,
+          "requires": {
+            "@plotly/point-cluster": "^3.1.9",
+            "array-range": "^1.0.1",
+            "array-rearrange": "^2.2.2",
+            "clamp": "^1.0.1",
+            "color-id": "^1.1.0",
+            "color-normalize": "^1.5.0",
+            "color-rgba": "^2.1.1",
+            "flatten-vertex-data": "^1.0.2",
+            "glslify": "^7.0.0",
+            "image-palette": "^2.1.0",
+            "is-iexplorer": "^1.0.0",
+            "object-assign": "^4.1.1",
+            "parse-rect": "^1.2.0",
+            "pick-by-alias": "^1.2.0",
+            "to-float32": "^1.0.1",
+            "update-diff": "^1.1.0"
+          }
+        },
+        "regl-splom": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.12.tgz",
+          "integrity": "sha512-LliMmAQ6wJFuPiLxZgYOFOzjhWcrIWPbS3Vf763Twl6R8eKpuUyRHZ54q+hxWGYwICHoPCBKMs7pVAJi8Iv7/w==",
+          "dev": true,
+          "requires": {
+            "array-bounds": "^1.0.1",
+            "array-range": "^1.0.1",
+            "color-alpha": "^1.0.4",
+            "flatten-vertex-data": "^1.0.2",
+            "parse-rect": "^1.2.0",
+            "pick-by-alias": "^1.2.0",
+            "raf": "^3.4.1",
+            "regl-scatter2d": "^3.1.9"
+          }
+        },
+        "stack-trace": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+          "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+          "dev": true
+        },
+        "supercluster": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
+          "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
+          "dev": true,
+          "requires": {
+            "kdbush": "^3.0.0"
+          }
+        },
+        "tinycolor2": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+          "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+          "dev": true
+        },
+        "to-px": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+          "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+          "dev": true,
+          "requires": {
+            "parse-unit": "^1.0.1"
+          }
+        },
+        "topojson-client": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+          "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+          "dev": true,
+          "requires": {
+            "commander": "2"
+          }
+        }
       }
     },
     "plugin-error": {
@@ -17733,26 +17647,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "point-cluster": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.8.tgz",
-      "integrity": "sha512-7klIr45dpMeZuqjIK9+qBg3m2IhyZJNJkdqjJFw0Olq75FM8ojrTMjClVUrMjNYRVqtwztxCHH71Fyjhg+YwyQ==",
-      "dev": true,
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-normalize": "^1.1.4",
-        "binary-search-bounds": "^2.0.4",
-        "bubleify": "^1.1.0",
-        "clamp": "^1.0.1",
-        "defined": "^1.0.0",
-        "dtype": "^2.0.0",
-        "flatten-vertex-data": "^1.0.2",
-        "is-obj": "^1.0.1",
-        "math-log2": "^1.0.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0"
-      }
     },
     "point-in-big-polygon": {
       "version": "2.0.0",
@@ -18081,73 +17975,6 @@
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "dev": true
     },
-    "quote-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-      "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -18286,23 +18113,6 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "dev": true,
-      "requires": {
-        "esprima": "~1.0.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-          "dev": true
-        }
-      }
-    },
     "reduce-simplicial-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
@@ -18434,86 +18244,6 @@
       "resolved": "https://registry.npmjs.org/regl/-/regl-1.4.2.tgz",
       "integrity": "sha512-wc/kE6kGmGfQk3G9f1Pai4TZ0K1pWxkD1Jeaj6CxJwEiB1jwHgEpqD84G2t7F0DmNXfQh7IUnoG1opxoONJ7Xg==",
       "dev": true
-    },
-    "regl-error2d": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.8.tgz",
-      "integrity": "sha512-5nszdicXbimRUnYB42i+O7KPcla7PzI62nZLCP6qVRKlQCf3rSrWbikMNd1S84LE8+deWHWcb8rZ/v7rZ9qmmw==",
-      "dev": true,
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "bubleify": "^1.2.0",
-        "color-normalize": "^1.5.0",
-        "flatten-vertex-data": "^1.0.2",
-        "object-assign": "^4.1.1",
-        "pick-by-alias": "^1.2.0",
-        "to-float32": "^1.0.1",
-        "update-diff": "^1.1.0"
-      }
-    },
-    "regl-line2d": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.15.tgz",
-      "integrity": "sha512-RuQbg9iZ6MyuInG8izF6zjQ/2g4qL6sg1egiuFalWzaGSvuve/IWBsIcqKTlwpiEsRt9b4cHu9NYs2fLt1gYJw==",
-      "dev": true,
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-normalize": "^1.1.4",
-        "bubleify": "^1.2.0",
-        "color-normalize": "^1.5.0",
-        "earcut": "^2.1.5",
-        "es6-weak-map": "^2.0.3",
-        "flatten-vertex-data": "^1.0.2",
-        "glslify": "^7.0.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "to-float32": "^1.0.1"
-      }
-    },
-    "regl-scatter2d": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.8.tgz",
-      "integrity": "sha512-Z9MYAUx9t8e3MsiHBbJAEstbIqauXxzcL9DmuKXQuRWfCMF2DBytYJtE0FpbQU6639wEMAJ54SEIlISWF8sQ2g==",
-      "dev": true,
-      "requires": {
-        "array-range": "^1.0.1",
-        "array-rearrange": "^2.2.2",
-        "clamp": "^1.0.1",
-        "color-id": "^1.1.0",
-        "color-normalize": "1.5.0",
-        "color-rgba": "^2.1.1",
-        "flatten-vertex-data": "^1.0.2",
-        "glslify": "^7.0.0",
-        "image-palette": "^2.1.0",
-        "is-iexplorer": "^1.0.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "point-cluster": "^3.1.8",
-        "to-float32": "^1.0.1",
-        "update-diff": "^1.1.0"
-      }
-    },
-    "regl-splom": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.8.tgz",
-      "integrity": "sha512-4GQTgcArCbGLsXhgalWVBxeW7OXllnu+Gvil/4SbQQmtiqLCl+xgF79pISKY9mLXTlobxiX7cVKdjGjp25559A==",
-      "dev": true,
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-range": "^1.0.1",
-        "bubleify": "^1.2.0",
-        "color-alpha": "^1.0.4",
-        "defined": "^1.0.0",
-        "flatten-vertex-data": "^1.0.2",
-        "left-pad": "^1.3.0",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "point-cluster": "^3.1.8",
-        "raf": "^3.4.1",
-        "regl-scatter2d": "^3.1.2"
-      }
     },
     "relateurl": {
       "version": "0.2.7",
@@ -18737,15 +18467,6 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
     },
     "right-now": {
       "version": "1.0.0",
@@ -19018,12 +18739,6 @@
         "sver-compat": "^1.5.0"
       }
     },
-    "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -19063,25 +18778,6 @@
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
       "dev": true
-    },
-    "sharkdown": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
-      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
-      "dev": true,
-      "requires": {
-        "cardinal": "~0.4.2",
-        "minimist": "0.0.5",
-        "split": "~0.2.10"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
-          "dev": true
-        }
-      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -19377,12 +19073,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
     "sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -19420,15 +19110,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
-    },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
     },
     "split-polygon": {
       "version": "1.0.0",
@@ -19540,156 +19221,6 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
-          }
-        }
-      }
-    },
-    "static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^2.1.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-          "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
-          "dev": true,
-          "requires": {
-            "esprima": "~1.1.1",
-            "estraverse": "~1.5.0",
-            "esutils": "~1.0.0",
-            "source-map": "~0.1.33"
-          }
-        },
-        "esprima": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk=",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-          "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "static-eval": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-          "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
-          "dev": true,
-          "requires": {
-            "escodegen": "~0.0.24"
-          },
-          "dependencies": {
-            "escodegen": {
-              "version": "0.0.28",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-              "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
-              "dev": true,
-              "requires": {
-                "esprima": "~1.0.2",
-                "estraverse": "~1.3.0",
-                "source-map": ">= 0.1.2"
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-              "dev": true
-            },
-            "estraverse": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-              "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI=",
-              "dev": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
           }
         }
       }
@@ -19924,15 +19455,6 @@
       "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk=",
       "dev": true
     },
-    "supercluster": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-      "dev": true,
-      "requires": {
-        "kdbush": "^3.0.0"
-      }
-    },
     "superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
@@ -20114,16 +19636,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -20145,6 +19667,15 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         },
         "source-map": {
@@ -20255,12 +19786,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
       "dev": true
     },
     "tinyqueue": {
@@ -20395,15 +19920,6 @@
         "is-base64": "^0.1.0",
         "is-float-array": "^1.0.0",
         "to-array-buffer": "^3.0.0"
-      }
-    },
-    "topojson-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
-      "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
-      "dev": true,
-      "requires": {
-        "commander": "2"
       }
     },
     "toposort": {
@@ -20720,13 +20236,6 @@
           "dev": true
         }
       }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -21849,12 +21358,6 @@
         }
       }
     },
-    "wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY=",
-      "dev": true
-    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -21905,22 +21408,10 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "worker-farm": {

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -47,7 +47,7 @@
     "jest": "^25.0.0",
     "jest-canvas-mock": "^2.1.2",
     "jest-teamcity-reporter": "^0.9.0",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.1",
     "json-schema-to-typescript": "^8.2.0",
     "mathjs": "^7.5.1",
     "numeral": "^2.0.6",

--- a/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
+++ b/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
@@ -220,7 +220,7 @@ describe("plotly graph", () => {
             <g class='hoverlayer'>
                 <g id='test-path-add' class='hovertext'></g>
             </g>`);
-        $("#test-path-add").append("<rect x='60' y='0' width='200' height='40'/><path d='some default path'/>");
+        $("#test-path-add").append("<rect x='60' y='0' width='200' height='40'></rect><path d='some default path'></path>");
 
         setTimeout(() => {
             expect(wrapper!!.find("#test-path-add path").attributes().d).toBe("M4,-20v40H60v-40h-40l-6,-6l-6,6Z");
@@ -241,8 +241,8 @@ describe("plotly graph", () => {
         $(".hoverbelow").append(`
             <g class='hoverlayer'>
                 <g id='test-path-mutate' class='hovertext'>
-                    <rect x='90' y='0' width='200' height='40'/><path d='some default path'/>
-                </g>
+                    <rect x='90' y='0' width='200' height='40'></rect>
+                    <path d='some default path'></path>
             </g>`);
         $("#test-path-mutate rect").attr("x", "60");
         $("#test-path-mutate path").attr("d", "some new path");
@@ -267,7 +267,7 @@ describe("plotly graph", () => {
             <g class='hoverlayer'>
                 <g id='test-path-add' class='hovertext'></g>
             </g>`);
-        $("#test-path-add").append("<rect x='-260' y='0' width='200' height='40'/><path d='some default path'/>");
+        $("#test-path-add").append("<rect x='-260' y='0' width='200' height='40'/></rect><path d='some default path'></path>");
 
         setTimeout(() => {
             expect(wrapper!!.find("#test-path-add path").attributes().d).toBe("M-4,-20v40H-60v-40h40l6,-6l6,6Z");


### PR DESCRIPTION
The tests appeared to be failing because the append in the test was being misinterpreted as appending nested elements unless explicit end tags were included - this meant that the hoverbelow mutation observer was unable to find the expected mutated elements to update. 