### PR TITLE
mrc-2000 show all interventions on all graphs and figures

### DIFF
--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -30,7 +30,7 @@
         setup(props: Props) {
             const {filteredData} = useFiltering(props);
             const {evaluateFormula} = useTransformation(props);
-            const evaluateCell = (col: ColumnDefinition, row: any) => {
+            const evaluateCell = (col: ColumnDefinition, row: any): number | string => {
                 let value: string | number = "";
                 if (!col.valueTransform) {
                     value = row[col.valueCol]
@@ -41,7 +41,10 @@
                     return "n/a";
                 }
                 if (typeof value == "string") {
-                    return value;
+                    if (isNaN(parseFloat(value))) {
+                        return value;
+                    }
+                    value = parseFloat(value);
                 }
                 if (col.precision) {
                     value = value.toPrecision(col.precision)

--- a/src/app/static/src/app/components/figures/filteredData.ts
+++ b/src/app/static/src/app/components/figures/filteredData.ts
@@ -10,11 +10,7 @@ export interface FilteringProps {
 
 export function useFiltering(props: FilteringProps) {
 
-    const filterBySettings = (row: any) => {
-        if (!props.settings) {
-            return true;
-        }
-
+    const settings = computed<Dictionary<string | number> | null>(() => {
         let settings = props.settings;
         if (props.metadata && props.metadata.settings) {
             // filter to those settings specified in the metadata
@@ -24,16 +20,27 @@ export function useFiltering(props: FilteringProps) {
                     return acc
                 }, {} as Dictionary<string | number>)
         }
+        return settings;
+    })
 
-        for (let key of Object.keys(settings)) {
-            if (row[key] != undefined && (settings[key] === "" || row[key] != settings[key])) {
+    const filterBySettings = (row: any) => {
+
+        const settingsVal = settings.value;
+        if (!settingsVal) {
+            return true;
+        }
+
+        for (let key of Object.keys(settingsVal)) {
+            if (row[key] != undefined &&
+                (settingsVal[key] === "" || (row[key] != settingsVal[key] && row[key] != "n/a"))) {
                 return false;
             }
         }
+
         return true;
     };
 
-    const filteredData = computed<any[]>(() => props.data.filter((row: any) => filterBySettings(row)))
+    const filteredData = computed<any[]>(() => props.data.filter((row: any) => filterBySettings(row)));
 
     return {filteredData}
 }

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -8,25 +8,25 @@ describe("dynamic table", () => {
     const data: Data = [
         {
             "intervention": "none",
-            "net_use": 0.2,
+            "net_use": "n/a",
             "cases_averted": 0,
             "prev": 0.111
         },
         {
             "intervention": "none",
-            "net_use": 0.4,
+            "net_use": "0.4",
             "cases_averted": 0,
             "prev": 0.222
         },
         {
             "intervention": "ITN",
-            "net_use": 0.2,
+            "net_use": "0.2",
             "cases_averted": 3,
             "prev": 0.311
         },
         {
             "intervention": "ITN",
-            "net_use": 0.4,
+            "net_use": "0.4",
             "cases_averted": 3,
             "prev": 0.411
         }];
@@ -100,7 +100,7 @@ describe("dynamic table", () => {
         const rows = wrapper.findAll("tbody tr");
         expect(rows.length).toBe(2);
         expect(rows.at(0).find("td").text()).toBe("display name for none");
-        expect(rows.at(0).findAll("td").at(1).text()).toBe("0.2");
+        expect(rows.at(0).findAll("td").at(1).text()).toBe("n/a");
         expect(rows.at(1).find("td").text()).toBe("display name for ITN");
         expect(rows.at(1).findAll("td").at(1).text()).toBe("0.2");
     });
@@ -111,7 +111,7 @@ describe("dynamic table", () => {
         });
         const rows = wrapper.findAll("tbody tr");
         expect(rows.at(0).find("td").text()).toBe("display name for none");
-        expect(rows.at(0).findAll("td").at(1).text()).toBe("0.2"); // net use
+        expect(rows.at(0).findAll("td").at(1).text()).toBe("n/a"); // net use
         expect(rows.at(0).findAll("td").at(2).text()).toBe("0"); // cases averted
         expect(rows.at(0).findAll("td").at(3).text()).toBe("0.11"); // prev
         expect(rows.at(0).findAll("td").at(4).text()).toBe("5k"); // total costs

--- a/src/app/static/src/tests/components/figures/filteredData.test.ts
+++ b/src/app/static/src/tests/components/figures/filteredData.test.ts
@@ -35,6 +35,29 @@ describe("use filtering", () => {
 
     });
 
+    it("includes values where a setting is n/a", () => {
+
+        const props: FilteringProps = {
+            settings: {
+                "netUse": 0
+            },
+            data: [
+                {"month": 1, "intervention": "none", "netUse": "n/a", "value": 0.1},
+                {"month": 1, "intervention": "none", "netUse": "n/a", "value": 0.2},
+                {"month": 2, "intervention": "none", "netUse": "n/a", "value": 0.3},
+                {"month": 2, "intervention": "none", "netUse": "n/a", "value": 0.4},
+                {"month": 1, "intervention": "ITN", "netUse": 0, "value": 0.5},
+                {"month": 1, "intervention": "ITN", "netUse": 0.1, "value": 0.6},
+                {"month": 2, "intervention": "ITN", "netUse": 0, "value": 0.7},
+                {"month": 2, "intervention": "ITN", "netUse": 0.1, "value": 0.8}
+            ]
+        }
+
+        const result = useFiltering(props);
+        expect(result.filteredData.value.length).toBe(6);
+    });
+
+
     it("ignores settings that don't exist in the data", () => {
 
         const props = {

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2000


### PR DESCRIPTION
Very small change to the filtering logic - allow rows through where a setting is marked as "n/a" as well as those that match the settings. In conjunction with the data changes here https://github.com/mrc-ide/mintr/pull/30 results in all figures containing all interventions.