### PR TITLE
mrc-2071 Make tables sortable

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -5875,25 +5875,6 @@
         "whatwg-url": "^7.0.0"
       }
     },
-    "datatables.net": {
-      "version": "1.10.22",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.22.tgz",
-      "integrity": "sha512-ujn8GvkQIBYzYH54XY7OrI0Zb35TKRd9ABYfbnXgBfwTGIFT6UsmXrfHU5Yk+MSDoF0sDu2TB+31V6c+zUZ0Pw==",
-      "dev": true,
-      "requires": {
-        "jquery": ">=1.7"
-      }
-    },
-    "datatables.net-bs4": {
-      "version": "1.10.22",
-      "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.10.22.tgz",
-      "integrity": "sha512-si0eOiaKmuURURpXhPRba7b3vCZsVfJK8pfrlM5WtaOaCEBa62DG/S9guMxUBmcAmvEC3FA2CKc/iKya3gb9qg==",
-      "dev": true,
-      "requires": {
-        "datatables.net": "1.10.22",
-        "jquery": ">=1.7"
-      }
-    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -34,7 +34,6 @@
     "babel-loader": "^8.0.5",
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.4",
-    "datatables.net-bs4": "^1.10.22",
     "del": "^5.1.0",
     "gulp": "^4.0.0",
     "gulp-clean-css": "^4.0.0",

--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -2,7 +2,7 @@
     <b-table striped :items="items" :fields="fields"></b-table>
 </template>
 <script lang="ts">
-    import {defineComponent} from "@vue/composition-api";
+    import {computed, defineComponent} from "@vue/composition-api";
     import {FilteringProps, useFiltering} from "./filteredData";
     import {useTransformation} from "./transformedData";
     import numeral from "numeral";
@@ -43,23 +43,25 @@
                 }
                 return value;
             };
-            return {
-                fields: props.config.map((col, i) => (
+            const fields = props.config.map((col, i) => (
+                {
+                    key: `${col.valueCol}${i}`,
+                    label: col.displayName,
+                    sortable: true,
+                    thClass: "align-middle"
+                }
+            ));
+            const items = computed(() => filteredData.value.map((row) =>
+                props.config.reduce((item, col, i) => (
                     {
-                        key: `${col.valueCol}${i}`,
-                        label: col.displayName,
-                        sortable: true,
-                        thClass: "align-middle"
+                        ...item,
+                        [`${col.valueCol}${i}`]: evaluateCell(col, row)
                     }
-                )),
-                items:  filteredData.value.map((row) =>
-                    props.config.reduce((item, col, i) => (
-                        {
-                            ...item,
-                            [`${col.valueCol}${i}`]: evaluateCell(col, row)
-                        }
-                    ), {})
-                )
+                ), {})
+            ));
+            return {
+                fields,
+                items
             }
         }
     })

--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -1,18 +1,5 @@
 <template>
-    <table class="table table-responsive table-striped dataTable">
-        <thead>
-        <tr>
-            <th v-for="col in config">{{ col.displayName }}</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr v-for="row in filteredData">
-            <td v-for="col in config">
-                <span>{{ evaluateCell(col, row) }}</span>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <b-table striped :items="items" :fields="fields"></b-table>
 </template>
 <script lang="ts">
     import {defineComponent} from "@vue/composition-api";
@@ -20,6 +7,7 @@
     import {useTransformation} from "./transformedData";
     import numeral from "numeral";
     import {ColumnDefinition} from "../../generated";
+    import {BTable} from "bootstrap-vue";
 
     interface Props extends FilteringProps {
         config: ColumnDefinition[]
@@ -27,6 +15,7 @@
 
     export default defineComponent({
         props: {data: Array, config: Array, settings: Object},
+        components: {BTable},
         setup(props: Props) {
             const {filteredData} = useFiltering(props);
             const {evaluateFormula} = useTransformation(props);
@@ -55,8 +44,22 @@
                 return value;
             };
             return {
-                filteredData,
-                evaluateCell
+                fields: props.config.map((col, i) => (
+                    {
+                        key: `${col.valueCol}${i}`,
+                        label: col.displayName,
+                        sortable: true,
+                        thClass: "align-middle"
+                    }
+                )),
+                items:  filteredData.value.map((row) =>
+                    props.config.reduce((item, col, i) => (
+                        {
+                            ...item,
+                            [`${col.valueCol}${i}`]: evaluateCell(col, row)
+                        }
+                    ), {})
+                )
             }
         }
     })

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -6,7 +6,6 @@
 @import "partials/interventions.scss";
 @import "partials/graph.scss";
 @import '../../node_modules/bootstrap-vue/dist/bootstrap-vue.css';
-@import "../../node_modules/datatables.net-bs4/css/dataTables.bootstrap4.css";
 
 html {
   overflow-y: scroll;

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -2,6 +2,7 @@ import dynamicTable from "../../../app/components/figures/dynamicTable.vue";
 
 import {mount} from "@vue/test-utils";
 import {ColumnDefinition, Data} from "../../../app/generated";
+import Vue from "vue";
 
 describe("dynamic table", () => {
 
@@ -103,6 +104,17 @@ describe("dynamic table", () => {
         expect(rows.at(0).findAll("td").at(1).text()).toBe("n/a");
         expect(rows.at(1).find("td").text()).toBe("display name for ITN");
         expect(rows.at(1).findAll("td").at(1).text()).toBe("0.2");
+    });
+
+    it.skip("re-filters rows when settings change", async () => {
+        const wrapper = mount(dynamicTable, {
+            propsData: {data, config, settings}
+        });
+        const rows = wrapper.findAll("tbody tr");
+        expect(rows.length).toBe(2);
+        wrapper.setProps({settings: {...settings, net_use: 0.4}});
+        await Vue.nextTick();
+        expect(rows.length).toBe(3);
     });
 
     it("formats cells", () => {

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -1,6 +1,6 @@
 import dynamicTable from "../../../app/components/figures/dynamicTable.vue";
 
-import {shallowMount} from "@vue/test-utils";
+import {mount} from "@vue/test-utils";
 import {ColumnDefinition, Data} from "../../../app/generated";
 
 describe("dynamic table", () => {
@@ -80,21 +80,21 @@ describe("dynamic table", () => {
     }
 
     it("adds headers from definitions", () => {
-        const wrapper = shallowMount(dynamicTable, {
+        const wrapper = mount(dynamicTable, {
             propsData: {data, config, settings}
         });
         const headers = wrapper.findAll("th");
         expect(headers.length).toBe(6);
-        expect(headers.at(0).text()).toBe("Intervention");
-        expect(headers.at(1).text()).toBe("Net use");
-        expect(headers.at(2).text()).toBe("Cases averted");
-        expect(headers.at(3).text()).toBe("Prevalence");
-        expect(headers.at(4).text()).toBe("Total costs");
-        expect(headers.at(5).text()).toBe("Cost per case averted");
+        expect(headers.at(0).text()).toContain("Intervention");
+        expect(headers.at(1).text()).toContain("Net use");
+        expect(headers.at(2).text()).toContain("Cases averted");
+        expect(headers.at(3).text()).toContain("Prevalence");
+        expect(headers.at(4).text()).toContain("Total costs");
+        expect(headers.at(5).text()).toContain("Cost per case averted");
     });
 
     it("filters rows by settings", () => {
-        const wrapper = shallowMount(dynamicTable, {
+        const wrapper = mount(dynamicTable, {
             propsData: {data, config, settings}
         });
         const rows = wrapper.findAll("tbody tr");
@@ -106,7 +106,7 @@ describe("dynamic table", () => {
     });
 
     it("formats cells", () => {
-        const wrapper = shallowMount(dynamicTable, {
+        const wrapper = mount(dynamicTable, {
             propsData: {data, config, settings}
         });
         const rows = wrapper.findAll("tbody tr");

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -106,15 +106,13 @@ describe("dynamic table", () => {
         expect(rows.at(1).findAll("td").at(1).text()).toBe("0.2");
     });
 
-    it.skip("re-filters rows when settings change", async () => {
+    it("re-filters rows when settings change", async () => {
         const wrapper = mount(dynamicTable, {
             propsData: {data, config, settings}
         });
-        const rows = wrapper.findAll("tbody tr");
-        expect(rows.length).toBe(2);
-        wrapper.setProps({settings: {...settings, net_use: 0.4}});
-        await Vue.nextTick();
-        expect(rows.length).toBe(3);
+        expect(wrapper.findAll("tbody tr").length).toBe(2);
+        await wrapper.setProps({settings: {...settings, net_use: 0.4}});
+        expect(wrapper.findAll("tbody tr").length).toBe(3);
     });
 
     it("formats cells", () => {


### PR DESCRIPTION
* Use BootstrapVue's Table component, which provides sorting
* This table has its own styling, meaning that we no longer need to import datatables.net-bs4 for its CSS
* It requires unique column names, so columns are suffixed with their index in order to differentiate between columns that have a `valueTransform` based on a shared `valueCol` (e.g. Total costs)
* Column headings now contain hidden accessibility text, so we use `toContain` rather than `toBe` in tests
* It does _not_ change the default row ordering, which remains inconsistent with the legacy app. Resolving this (if necessary) would require a change to mintr. 