### PR TITLE
mrc-2086 Replace cost vs efficacy figure with cost per case averted barchart

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/APIClient.kt
@@ -17,7 +17,7 @@ interface APIClient {
     fun getImpactGraphPrevalenceData(dataOptions: Map<String, Any>): ResponseEntity<String>
     fun getImpactTableConfig(): ResponseEntity<String>
     fun getCostCasesAvertedGraphConfig(): ResponseEntity<String>
-    fun getCostEfficacyGraphConfig(): ResponseEntity<String>
+    fun getCostPerCaseGraphConfig(): ResponseEntity<String>
     fun getCostTableConfig(): ResponseEntity<String>
     fun getTableData(dataOptions: Map<String, Any>): ResponseEntity<String>
     fun getImpactDocs(): ResponseEntity<String>
@@ -68,8 +68,8 @@ class MintrAPIClient(
         return get("graph/cost/cases-averted/config")
     }
 
-    override fun getCostEfficacyGraphConfig(): ResponseEntity<String> {
-        return get("graph/cost/efficacy/config")
+    override fun getCostPerCaseGraphConfig(): ResponseEntity<String> {
+        return get("graph/cost/per-case/config")
     }
 
     override fun getCostTableConfig(): ResponseEntity<String> {

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/CostController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/CostController.kt
@@ -13,10 +13,10 @@ class CostController(private val apiClient: APIClient) {
         return apiClient.getCostCasesAvertedGraphConfig()
     }
 
-    @GetMapping("/graph/efficacy/config")
+    @GetMapping("/graph/per-case/config")
     @ResponseBody
-    fun graphEfficacyConfig(): ResponseEntity<String> {
-        return apiClient.getCostEfficacyGraphConfig()
+    fun graphCostPerCaseConfig(): ResponseEntity<String> {
+        return apiClient.getCostPerCaseGraphConfig()
     }
 
     @GetMapping("/table/config")

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
@@ -74,9 +74,9 @@ class MintrAPIClientTests {
     }
 
     @Test
-    fun `can get graph cost efficacy config`() {
+    fun `can get graph cost per case config`() {
         val sut = MintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
-        val result = sut.getCostEfficacyGraphConfig()
+        val result = sut.getCostPerCaseGraphConfig()
         assertThat(result.statusCodeValue).isEqualTo(200)
         JSONValidator().validateSuccess(result.body!!, "Graph")
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/CostTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/CostTests.kt
@@ -13,8 +13,8 @@ class CostTests: EndpointTests() {
     }
 
     @Test
-    fun `can get cost graph efficacy config`() {
-        val responseEntity = testRestTemplate.getForEntity<String>("/cost/graph/efficacy/config")
+    fun `can get cost graph per case config`() {
+        val responseEntity = testRestTemplate.getForEntity<String>("/cost/graph/per-case/config")
         assertSuccess(responseEntity, "Graph")
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/CostControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/CostControllerTests.kt
@@ -23,14 +23,14 @@ class CostControllerTests {
     }
 
     @Test
-    fun `gets graph efficacy config from the api`()
+    fun `gets graph per case config from the api`()
     {
         val mockAPI = mock<APIClient>{
-            on{ getCostEfficacyGraphConfig() } doReturn mockResponse
+            on{ getCostPerCaseGraphConfig() } doReturn mockResponse
         }
 
         val sut = CostController(mockAPI)
-        assertThat(sut.graphEfficacyConfig()).isSameAs(mockResponse)
+        assertThat(sut.graphCostPerCaseConfig()).isSameAs(mockResponse)
     }
 
     @Test

--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -12,7 +12,7 @@ export enum RootAction {
     FetchCasesGraphConfig = "FetchCasesGraphConfig",
     FetchImpactTableConfig = "FetchImpactTableConfig",
     FetchCostCasesGraphConfig = "FetchCostCasesGraphConfig",
-    FetchCostEfficacyGraphConfig = "FetchCostEfficacyGraphConfig",
+    FetchCostPerCaseGraphConfig = "FetchCostPerCaseGraphConfig",
     FetchCostTableConfig = "FetchCostTableConfig",
     FetchBaselineOptions = "FetchBaselineOptions",
     FetchInterventionOptions = "FetchInterventionOptions",
@@ -97,11 +97,11 @@ export const actions: ActionTree<RootState, RootState> = {
             .get<Graph>("/cost/graph/cases-averted/config");
     },
 
-    async [RootAction.FetchCostEfficacyGraphConfig](context) {
+    async [RootAction.FetchCostPerCaseGraphConfig](context) {
         await api(context)
-            .withSuccess(RootMutation.AddCostEfficacyGraphConfig)
+            .withSuccess(RootMutation.AddCostPerCaseGraphConfig)
             .withError(RootMutation.AddError)
-            .get<Graph>("/cost/graph/efficacy/config");
+            .get<Graph>("/cost/graph/per-case/config");
     },
 
     async [RootAction.FetchTableData](context) {
@@ -166,7 +166,7 @@ export const actions: ActionTree<RootState, RootState> = {
             context.dispatch(RootAction.FetchCasesGraphConfig),
             context.dispatch(RootAction.FetchImpactTableConfig),
             context.dispatch(RootAction.FetchCostCasesGraphConfig),
-            context.dispatch(RootAction.FetchCostEfficacyGraphConfig),
+            context.dispatch(RootAction.FetchCostPerCaseGraphConfig),
             context.dispatch(RootAction.FetchCostTableConfig)
         ]);
     }

--- a/src/app/static/src/app/components/costEffectiveness.vue
+++ b/src/app/static/src/app/components/costEffectiveness.vue
@@ -1,15 +1,15 @@
 <template>
     <div>
-        <plotly-graph v-if="activeTab === 'Graphs' && efficacyGraphConfig"
-                      :layout="efficacyGraphConfig.layout"
-                      :metadata="efficacyGraphConfig.metadata"
-                      :series="efficacyGraphConfig.series"
-                      :data="tableData"
-                      :settings="settings"></plotly-graph>
         <plotly-graph v-if="activeTab === 'Graphs' && casesAvertedGraphConfig"
                       :layout="casesAvertedGraphConfig.layout"
                       :metadata="casesAvertedGraphConfig.metadata"
                       :series="casesAvertedGraphConfig.series"
+                      :data="tableData"
+                      :settings="settings"></plotly-graph>
+        <plotly-graph v-if="activeTab === 'Graphs' && perCaseGraphConfig"
+                      :layout="perCaseGraphConfig.layout"
+                      :metadata="perCaseGraphConfig.metadata"
+                      :series="perCaseGraphConfig.series"
                       :data="tableData"
                       :settings="settings"></plotly-graph>
 
@@ -34,7 +34,7 @@
     interface Computed {
         settings: DynamicFormData | null,
         currentProject: Project | null,
-        efficacyGraphConfig: Graph,
+        perCaseGraphConfig: Graph,
         casesAvertedGraphConfig: Graph,
         tableData: Data,
         tableConfig: TableDefinition | null
@@ -51,7 +51,7 @@
                 ...state.currentProject.currentRegion.baselineSettings
             }),
             currentProject: mapStateProp<RootState, Project | null>(state => state.currentProject),
-            efficacyGraphConfig: mapStateProp<RootState, Graph | null>(state => state.costEfficacyGraphConfig),
+            perCaseGraphConfig: mapStateProp<RootState, Graph | null>(state => state.costPerCaseGraphConfig),
             casesAvertedGraphConfig: mapStateProp<RootState, Graph | null>(state => state.costCasesGraphConfig),
             tableConfig: mapStateProp<RootState, TableDefinition | null>(state => state.costTableConfig),
             docs: mapStateProp<RootState, string>(state => state.costDocs),

--- a/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
@@ -1,6 +1,7 @@
 import {computed} from "@vue/composition-api";
 import {LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
 import {FilteringProps, useFiltering} from "../filteredData";
+import {useTransformation} from "../transformedData";
 
 interface Props extends FilteringProps {
     series: SeriesDefinition[]
@@ -9,6 +10,7 @@ interface Props extends FilteringProps {
 
 export function useWideFormatData(props: Props) {
     const {filteredData} = useFiltering(props);
+    const {evaluateFormula} = useTransformation(props);
 
     const getRow = (id: string) => {
         return filteredData.value.find((row: any) => row[props.metadata.id_col] == id);
@@ -39,7 +41,9 @@ export function useWideFormatData(props: Props) {
                 const error_y = d.error_y && getErrorBar(row, d.error_y)
                 const def: SeriesDefinition = {
                     ...d,
-                    y: meta.cols.map((c: string) => row[c])
+                    y: d.y_formula
+                        ? d.y_formula.map(formula => evaluateFormula(formula, row))
+                        : meta.cols && meta.cols.map((c: string) => row[c])
                 }
                 if (error_y) {
                     def.error_y = error_y

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -10,6 +10,7 @@ export type Data = {
 export interface DataOptions {
   [k: string]: any;
 }
+export type Docs = string;
 export interface DynamicFormOptions {
   controlSections: ControlSection[];
 }
@@ -17,6 +18,8 @@ export interface ControlSection {
   label: string;
   description?: string;
   controlGroups: ControlGroup[];
+  documentation?: string;
+  collapsible?: boolean;
 }
 export interface ControlGroup {
   label?: string;
@@ -36,6 +39,7 @@ export interface SelectControl {
       [k: string]: any;
     }[];
   }[];
+  excludeNullOption?: boolean;
 }
 export interface NumberControl {
   name: string;
@@ -70,7 +74,7 @@ export interface LongFormatMetadata {
   settings?: string[];
 }
 export interface WideFormatMetadata {
-  cols: string[];
+  cols?: string[];
   id_col: string;
   format: "wide";
   settings?: string[];

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -25,7 +25,7 @@ export enum RootMutation {
     AddCostCasesGraphConfig = "AddCostCasesGraphConfig",
     AddTableData = "AddTableData",
     AddCostTableConfig = "AddCostTableConfig",
-    AddCostEfficacyGraphConfig = "AddCostEfficacyGraphConfig",
+    AddCostPerCaseGraphConfig = "AddCostPerCaseGraphConfig",
     DeleteProject = "DeleteProject",
     UpdateImpactDocs = "UpdateImpactDocs",
     UpdateCostDocs = "UpdateCostDocs"
@@ -135,8 +135,8 @@ export const mutations: MutationTree<RootState> = {
         state.costTableConfig = payload
     },
 
-    [RootMutation.AddCostEfficacyGraphConfig](state: RootState, payload: Graph) {
-        state.costEfficacyGraphConfig = payload;
+    [RootMutation.AddCostPerCaseGraphConfig](state: RootState, payload: Graph) {
+        state.costPerCaseGraphConfig = payload;
     },
 
     [RootMutation.UpdateImpactDocs](state: RootState, payload: string) {

--- a/src/app/static/src/app/store.ts
+++ b/src/app/static/src/app/store.ts
@@ -21,7 +21,7 @@ export interface RootState {
     impactTableConfig: TableDefinition | null
     costCasesGraphConfig: Graph | null
     costTableConfig: TableDefinition | null
-    costEfficacyGraphConfig: Graph | null
+    costPerCaseGraphConfig: Graph | null
     impactDocs: string
     costDocs: string
 }
@@ -47,7 +47,7 @@ const storeOptions: StoreOptions<RootState> = {
         impactTableConfig: null,
         costCasesGraphConfig: null,
         costTableConfig: null,
-        costEfficacyGraphConfig: null,
+        costPerCaseGraphConfig: null,
         impactDocs: "",
         costDocs: "",
         ...existingState

--- a/src/app/static/src/tests/components/costEffectiveness.test.ts
+++ b/src/app/static/src/tests/components/costEffectiveness.test.ts
@@ -7,7 +7,7 @@ import plotlyGraph from "../../app/components/figures/graphs/plotlyGraph.vue";
 import dynamicTable from "../../app/components/figures/dynamicTable.vue";
 import collapsibleDocs from "../../app/components/collapsibleDocs.vue";
 
-describe("costEffectiveness", () => {
+describe("costPerCase", () => {
 
     const createStore = (state: Partial<RootState> = {}) => {
         return new Vuex.Store({
@@ -38,7 +38,7 @@ describe("costEffectiveness", () => {
 
     it("renders as expected when activeTab is Graphs", function () {
         const state = {
-            costEfficacyGraphConfig:  mockGraph({
+            costPerCaseGraphConfig:  mockGraph({
                 layout: {
                     whatever: 1
                 },
@@ -48,7 +48,7 @@ describe("costEffectiveness", () => {
                 metadata: {
                     format: "long",
                     id_col: "intervention",
-                    x_col: "efficacy",
+                    x_col: "intervention",
                     y_col: "cost"
                 }
             }),
@@ -76,13 +76,13 @@ describe("costEffectiveness", () => {
 
         const wrapper = shallowMount(costEffectiveness, {propsData: {activeTab: "Graphs"}, store});
 
-        const efficacyGraph = wrapper.findAll(plotlyGraph).at(0);
-        expect(efficacyGraph.props().layout).toBe(state.costEfficacyGraphConfig.layout);
-        expect(efficacyGraph.props().metadata).toBe(state.costEfficacyGraphConfig.metadata);
-        expect(efficacyGraph.props().series).toBe(state.costEfficacyGraphConfig.series);
-        expect(efficacyGraph.props().data).toBe(state.currentProject.currentRegion.tableData);
+        const costPerCaseGraph = wrapper.findAll(plotlyGraph).at(1);
+        expect(costPerCaseGraph.props().layout).toBe(state.costPerCaseGraphConfig.layout);
+        expect(costPerCaseGraph.props().metadata).toBe(state.costPerCaseGraphConfig.metadata);
+        expect(costPerCaseGraph.props().series).toBe(state.costPerCaseGraphConfig.series);
+        expect(costPerCaseGraph.props().data).toBe(state.currentProject.currentRegion.tableData);
 
-        const casesGraph = wrapper.findAll(plotlyGraph).at(1);
+        const casesGraph = wrapper.findAll(plotlyGraph).at(0);
         expect(casesGraph.props().layout).toBe(state.costCasesGraphConfig.layout);
         expect(casesGraph.props().metadata).toBe(state.costCasesGraphConfig.metadata);
         expect(casesGraph.props().series).toBe(state.costCasesGraphConfig.series);

--- a/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
@@ -145,5 +145,35 @@ describe("wide format data series", () => {
         });
     });
 
+    it("uses formulae if provided", () => {
+        const localProps = {
+            ...props,
+            series: [
+                {
+                    x: ["Pyrethoid ITN"],
+                    id: "ITN",
+                    y_formula: ["{cases_averted} - {cases_averted_low}"]
+                },
+                {
+                    x: ["Switch to Pyrethoid-PBO ITN"],
+                    id: "PBO",
+                    y_formula: ["{cases_averted_high} - {cases_averted}"]
+                }
+            ]
+        }
+        const dataSeries = useWideFormatData(localProps).dataSeries.value;
+        expect(dataSeries.length).toBe(2);
+        expect(dataSeries[0]).toEqual({
+            id: "ITN",
+            x: ["Pyrethoid ITN"],
+            y: [10],
+            y_formula: ["{cases_averted} - {cases_averted_low}"]
+        });
+        expect(dataSeries[1]).toEqual({
+            id: "PBO",
+            x: ["Switch to Pyrethoid-PBO ITN"],
+            y: [50],
+            y_formula: ["{cases_averted_high} - {cases_averted}"]
+        });
+    });
 });
-

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -68,12 +68,12 @@ describe("actions", () => {
         expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostCasesGraphConfig);
     });
 
-    it("can get cost efficacy graph config", async () => {
+    it("can get cost per case graph config", async () => {
         const commit = jest.fn();
 
-        await (actions[RootAction.FetchCostEfficacyGraphConfig] as any)({commit} as any);
+        await (actions[RootAction.FetchCostPerCaseGraphConfig] as any)({commit} as any);
 
-        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostEfficacyGraphConfig);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostPerCaseGraphConfig);
         expect(commit.mock.calls[0][1].layout.title).toBeDefined(); // just confirm it's the expected type
     });
 

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -17,7 +17,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         impactTableConfig: null,
         costCasesGraphConfig: null,
         costTableConfig: null,
-        costEfficacyGraphConfig: null,
+        costPerCaseGraphConfig: null,
         impactDocs: "",
         costDocs: "",
         ...state

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -209,7 +209,7 @@ describe("actions", () => {
         expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchCasesGraphConfig);
         expect(dispatch.mock.calls[2][0]).toBe(RootAction.FetchImpactTableConfig);
         expect(dispatch.mock.calls[3][0]).toBe(RootAction.FetchCostCasesGraphConfig);
-        expect(dispatch.mock.calls[4][0]).toBe(RootAction.FetchCostEfficacyGraphConfig);
+        expect(dispatch.mock.calls[4][0]).toBe(RootAction.FetchCostPerCaseGraphConfig);
         expect(dispatch.mock.calls[5][0]).toBe(RootAction.FetchCostTableConfig);
     });
 
@@ -230,21 +230,21 @@ describe("actions", () => {
         expectAddsErrorOn500(actions[RootAction.FetchCostCasesGraphConfig], url);
     });
 
-    it("fetches cost efficacy config", async () => {
-        const url = "/cost/graph/efficacy/config";
+    it("fetches cost per case config", async () => {
+        const url = "/cost/graph/per-case/config";
         const testConfig = {data: {test: 1}, layout: {test_layout: "TEST"}};
         mockAxios.onGet(url)
             .reply(200, mockSuccess(testConfig));
 
         const commit = jest.fn();
-        await (actions[RootAction.FetchCostEfficacyGraphConfig] as any)({commit} as any);
+        await (actions[RootAction.FetchCostPerCaseGraphConfig] as any)({commit} as any);
 
         expect(mockAxios.history.get[0].url).toBe(url);
 
-        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostEfficacyGraphConfig);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.AddCostPerCaseGraphConfig);
         expect(commit.mock.calls[0][1]).toStrictEqual(testConfig);
 
-        expectAddsErrorOn500(actions[RootAction.FetchCostEfficacyGraphConfig], url);
+        expectAddsErrorOn500(actions[RootAction.FetchCostPerCaseGraphConfig], url);
     });
 
     it("EnsureImpactData fetches all impact figure data if none already present", async () => {

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -210,11 +210,11 @@ describe("mutations", () => {
         expect(state.costCasesGraphConfig).toStrictEqual(["config data"]);
     });
 
-    it("adds cost efficacy graph config", () => {
+    it("adds cost per case graph config", () => {
         const state = mockRootState();
-        mutations[RootMutation.AddCostEfficacyGraphConfig](state, ["config data"]);
+        mutations[RootMutation.AddCostPerCaseGraphConfig](state, ["config data"]);
 
-        expect(state.costEfficacyGraphConfig).toStrictEqual(["config data"]);
+        expect(state.costPerCaseGraphConfig).toStrictEqual(["config data"]);
     });
 
     it("updates the current region's intervention options", () => {

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2086


### PR DESCRIPTION
As with mrc-ide/mintr#39 (a pre-requisite PR), this is mainly renaming, apart from adding ability to use formulae for bar charts.

![Screenshot from 2021-01-11 12-28-41](https://user-images.githubusercontent.com/1724545/104182614-9f0f8c80-5408-11eb-86b8-198ad7709f1e.png)

Note that this chart does not (yet) include error bars. They can just about be added by allowing formulae to be used in `error.cols[minus]` and using rescaled error values for `casesAvertedPer1000` as a proxy for `casesAvertedError[Plus|Minus]` but this needs discussion - I will open a new ticket. See mrc-2104 and mrc-2088 for related issues.