### PR TITLE
mrc-2085 Support formulae in layout lines

### DIFF
--- a/src/app/static/src/app/components/figures/graphs/layout.ts
+++ b/src/app/static/src/app/components/figures/graphs/layout.ts
@@ -1,0 +1,24 @@
+import {TransformationProps, useTransformation} from "../transformedData";
+import {Dictionary} from "vue-router/types/router";
+import {deepCopy} from "../../../utils";
+
+interface Props extends TransformationProps {
+    layout: Dictionary<any>
+}
+
+export function useLayout(props: Props) {
+    const layout = deepCopy(props.layout);
+    const {evaluateFormula} = useTransformation(props);
+
+    // Currently supports transformation to horizontal line only
+    if (layout.shapes) {
+        layout.shapes.map((shape: any) => {
+            if (shape.type == "line" && shape.y_formula) {
+                const y = evaluateFormula(shape.y_formula);
+                shape.y0 = y;
+                shape.y1 = y;
+            }
+        });
+    }
+    return layout;
+}

--- a/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
+++ b/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="{hoverbelow: hoverBelow}">
-        <plotly :data="dataSeries" :layout="layoutWithFont" :display-mode-bar="true"></plotly>
+        <plotly :data="dataSeries" :layout="transformedLayout" :display-mode-bar="true"></plotly>
     </div>
 </template>
 <script lang="ts">
@@ -12,6 +12,7 @@
     import {setupHoverBelowObserver} from "./hoverBelow";
     import {Dictionary} from "vue-router/types/router";
     import {LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
+    import {useLayout} from "./layout";
 
     interface Props extends FilteringProps {
         series: SeriesDefinition[]
@@ -39,8 +40,8 @@
                 dataSeries = useWideFormatData(props).dataSeries
             }
 
-            const layoutWithFont = computed<any>(() => ({
-                ...props.layout,
+            const transformedLayout = computed<any>(() => ({
+                ...useLayout(props),
                 font: {
                     // use the same font settings as Bootstrap, which the rest of the app uses
                     family: '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"',
@@ -50,7 +51,7 @@
             }))
 
             return {
-                layoutWithFont,
+                transformedLayout,
                 dataSeries,
                 hoverBelow,
                 observer //Not required but makes testing much easier

--- a/src/app/static/src/tests/components/figures/layout.test.ts
+++ b/src/app/static/src/tests/components/figures/layout.test.ts
@@ -1,0 +1,68 @@
+import {useLayout} from "../../../app/components/figures/graphs/layout";
+
+describe("layout", () => {
+    const settings = {zonal_budget: 1000};
+
+    it("set y values for line shapes where y_formula is set", () => {
+        const layout = {
+            shapes: [
+                {
+                    type: "line",
+                    y_formula: "{zonal_budget}",
+                    x0: 0,
+                    x1: 1
+                },
+                {
+                    type: "line",
+                    y_formula: "{zonal_budget} * 2",
+                    x0: 0,
+                    x1: 2
+                }
+            ]
+        };
+
+        const transformedLayout = useLayout({layout, settings});
+        expect(transformedLayout.shapes).toStrictEqual([
+            {...layout.shapes[0], y0: 1000, y1: 1000},
+            {...layout.shapes[1], y0: 2000, y1: 2000}
+        ]);
+    });
+
+    it("does not update non-line shapes", () => {
+        const layout = {
+            shapes: [
+                {
+                    type: "line",
+                    y_formula: "{zonal_budget}",
+                },
+                {
+                    type: "rect",
+                    y_formula: "{zonal_budget} * 2"
+                }
+            ]
+        };
+
+        const transformedLayout = useLayout({layout, settings});
+        expect(transformedLayout.shapes).toStrictEqual([
+            {...layout.shapes[0], y0: 1000, y1: 1000},
+            {...layout.shapes[1]}
+        ]);
+    });
+
+    it("does nothing when y_formula is not set", () => {
+        const layout = {
+            shapes: [
+                {
+                    type: "line",
+                    x0: 0,
+                    x1: 1,
+                    y0: 100,
+                    y1: 200
+                }
+            ]
+        };
+
+        const transformedLayout = useLayout({layout, settings});
+        expect(transformedLayout).toStrictEqual(layout);
+    });
+});

--- a/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
+++ b/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
@@ -119,6 +119,36 @@ describe("plotly graph", () => {
         });
     });
 
+    it("uses transformed layout", () => {
+        const layout = {
+            shapes: [
+                {type: "line", y_formula: "{net_use}", x0: 0, x1: 1}
+            ]
+        };
+        wrapper = mount(plotlyGraph, {
+            propsData: {
+                series: [],
+                metadata: {
+                    x_col: "month",
+                    y_col: "value",
+                    id_col: "intervention",
+                    format: "long"
+                },
+                layout,
+                data: [],
+                settings: {
+                    net_use: 0.5
+                }
+            }
+        });
+
+        expect(wrapper.find(Plotly).props("layout").shapes).toStrictEqual([{
+            ...layout.shapes[0],
+            y0: 0.5,
+            y1: 0.5
+        }]);
+    });
+
     const hoverbelowPropsData = {
         series: [
             {x: ["ITN"], id: "ITN", name: "Pyrethoid ITN"},

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2085


### PR DESCRIPTION
Add support for formulae to calculate y values for non-series shapes. This currently just supports horizontal lines, where  x0 and x1 are hardcoded in the layout. Uses the existing evaluate code which is already in use for data series y values. This allows us to add a zonal budget line to the cost graphs. 

Targets https://github.com/mrc-ide/mintr/pull/38, which provides the relevant layout for this line. 