### PR TITLE
mrc-2104 Fix error intervals in charts and tables

### DIFF
--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -14,6 +14,7 @@
     import {evaluate} from "mathjs/number";
     import {ColumnDefinition} from "../../generated";
     import {BTable} from "bootstrap-vue";
+    import {getErrorInterval} from "./errorInterval";
 
     interface Props extends FilteringProps {
         config: ColumnDefinition[]
@@ -72,9 +73,8 @@
                     if (typeof value === "number" && col.error) {
                         const valuePlus = <number>evaluateCell({...col, ...col.error.plus}, row);
                         const valueMinus = <number>evaluateCell({...col, ...col.error.minus}, row);
-                        const plus = Math.max(valuePlus, valueMinus, value) - value;
-                        const minus = value - Math.min(valuePlus, valueMinus, value);
-                        item.tooltip = `${item.text} +${formatCell(col, plus)} / -${formatCell(col, minus)}`
+                        const errorInterval = getErrorInterval(valueMinus, value, valuePlus);
+                        item.tooltip = `${item.text} +${formatCell(col, errorInterval.plus)} / -${formatCell(col, errorInterval.minus)}`
                     }
                     return {...items, [`${col.valueCol}${i}`]: item};
                 }, {})

--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -72,7 +72,9 @@
                     if (typeof value === "number" && col.error) {
                         const valuePlus = <number>evaluateCell({...col, ...col.error.plus}, row);
                         const valueMinus = <number>evaluateCell({...col, ...col.error.minus}, row);
-                        item.tooltip = `${item.text} +${formatCell(col, valuePlus)} / -${formatCell(col, valueMinus)}`
+                        const plus = Math.max(valuePlus, valueMinus, value) - value;
+                        const minus = value - Math.min(valuePlus, valueMinus, value);
+                        item.tooltip = `${item.text} +${formatCell(col, plus)} / -${formatCell(col, minus)}`
                     }
                     return {...items, [`${col.valueCol}${i}`]: item};
                 }, {})

--- a/src/app/static/src/app/components/figures/errorInterval.ts
+++ b/src/app/static/src/app/components/figures/errorInterval.ts
@@ -1,0 +1,11 @@
+interface ErrorInterval {
+    plus: number;
+    minus: number;
+}
+
+export function getErrorInterval(low: number, mean: number, high: number): ErrorInterval {
+    return {
+      plus: Math.max(high, low, mean) - mean,
+      minus: mean - Math.min(high, low, mean)
+    };
+}

--- a/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
@@ -2,6 +2,7 @@ import {computed} from "@vue/composition-api";
 import {FilteringProps, useFiltering} from "../filteredData";
 import {LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
 import {useTransformation} from "../transformedData";
+import {getErrorInterval} from "../errorInterval";
 
 interface Props extends FilteringProps {
     series: SeriesDefinition[]
@@ -30,10 +31,7 @@ export function useLongFormatData(props: Props) {
                 }
 
                 if (error_col && error_col_minus) {
-                    error_array.push({
-                        plus: Math.max(row[error_col], row[meta.x_col], row[error_col_minus]) - row[meta.x_col],
-                        minus: row[meta.x_col] - Math.min(row[error_col], row[meta.x_col], row[error_col_minus])
-                    });
+                    error_array.push(getErrorInterval(row[error_col_minus], row[meta.x_col], row[error_col]));
                 }
             }
         });

--- a/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
@@ -19,8 +19,7 @@ export function useLongFormatData(props: Props) {
         const error_col = definition.error_x ? definition.error_x.col : null;
         const error_col_minus = definition.error_x ? definition.error_x.colminus : null;
 
-        const error_array = [] as any;
-        const error_array_minus = [] as any;
+        const error_array = [] as any[];
 
         filteredData.value.map((row: any) => {
             if (row[meta.id_col] == definition.id) {
@@ -31,8 +30,10 @@ export function useLongFormatData(props: Props) {
                 }
 
                 if (error_col && error_col_minus) {
-                    error_array.push(row[error_col]);
-                    error_array_minus.push(row[error_col_minus]);
+                    error_array.push({
+                        plus: Math.max(row[error_col], row[meta.x_col], row[error_col_minus]) - row[meta.x_col],
+                        minus: row[meta.x_col] - Math.min(row[error_col], row[meta.x_col], row[error_col_minus])
+                    });
                 }
             }
         });
@@ -43,8 +44,8 @@ export function useLongFormatData(props: Props) {
 
         const result = [x, y];
         if (error_array.length) {
-            result.push(error_array);
-            result.push(error_array_minus);
+            result.push(error_array.map(e => e.plus));
+            result.push(error_array.map(e => e.minus));
         }
 
         return result;

--- a/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
@@ -2,6 +2,7 @@ import {computed} from "@vue/composition-api";
 import {LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
 import {FilteringProps, useFiltering} from "../filteredData";
 import {useTransformation} from "../transformedData";
+import {getErrorInterval} from "../errorInterval";
 
 interface Props extends FilteringProps {
     series: SeriesDefinition[]
@@ -18,12 +19,11 @@ export function useWideFormatData(props: Props) {
 
     const getErrorBar = (row: any, error: any, y: any[]) => {
         const evaluate = (c: string) => c.match(/\{\w+\}/) ? evaluateFormula(c, row) : row[c];
-        const plus = error.cols.map(evaluate);
-        const minus = error.colsminus.map(evaluate);
+        const errorIntervals = y.map((e: number, i: number) => getErrorInterval(evaluate(error.colsminus[i]), e, evaluate(error.cols[i])));
         return {
             ...error,
-            array: y.map((e: number, i: number) => Math.max(plus[i], minus[i], e) - e),
-            arrayminus: y.map((e: number, i: number) => e - Math.min(plus[i], minus[i] , e))
+            array: errorIntervals.map(e => e.plus),
+            arrayminus: errorIntervals.map(e => e.minus)
         };
     };
     const dataSeries: any = computed(() => {

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -189,7 +189,16 @@ describe("dynamic table", () => {
                 "cases_averted_error_plus": 5,
                 "prev": 0.411,
                 "cases_averted_per_1000": 37
-            }
+            },
+            {
+                "intervention": "IRS",
+                "net_use": "0.2",
+                "cases_averted": 5,
+                "cases_averted_error_minus": 6,
+                "cases_averted_error_plus": 8,
+                "prev": 0.411,
+                "cases_averted_per_1000": 37
+            },
         ];
         const config: ColumnDefinition[] = [
             {
@@ -197,7 +206,8 @@ describe("dynamic table", () => {
                 valueCol: "intervention",
                 valueTransform: {
                     "none": "'display name for none'",
-                    "ITN": "'display name for ITN'"
+                    "ITN": "'display name for ITN'",
+                    "IRS": "'display name for IRS'"
                 }
             },
             {
@@ -217,19 +227,22 @@ describe("dynamic table", () => {
                 valueCol: "intervention",
                 valueTransform: {
                     "none": "{population} * {procure_people_per_net} / {cases_averted}",
-                    "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted}"
+                    "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted}",
+                    "IRS": "{population} * {procure_people_per_net} * 2 / {cases_averted}"
                 },
                 error: {
                     minus: {
                         valueTransform: {
                             "none": "{population} * {procure_people_per_net} / {cases_averted_error_plus}",
-                            "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_plus}"
+                            "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_plus}",
+                            "IRS": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_plus}"
                         }
                     },
                     plus: {
                         valueTransform: {
                             "none": "{population} * {procure_people_per_net} / {cases_averted_error_minus}",
-                            "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_minus}"
+                            "ITN": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_minus}",
+                            "IRS": "{population} * {procure_people_per_net} * 2 / {cases_averted_error_minus}"
                         }
                     }
                 },
@@ -240,6 +253,7 @@ describe("dynamic table", () => {
             propsData: {data, config, settings}
         });
         const rows = wrapper.findAll("tbody tr");
+
         expect(rows.at(0).find("td").text()).toBe("display name for none");
         expect(rows.at(0).findAll("td").at(1).text()).toBe("0"); // cases averted
         expect(rows.at(0).findAll("td").at(1).find("abbr").attributes().title).toBe("0 +0 / -0");
@@ -248,8 +262,15 @@ describe("dynamic table", () => {
 
         expect(rows.at(1).find("td").text()).toBe("display name for ITN");
         expect(rows.at(1).findAll("td").at(1).find("abbr").text()).toBe("3"); // cases averted
-        expect(rows.at(1).findAll("td").at(1).find("abbr").attributes().title).toBe("3 +4 / -1");
+        expect(rows.at(1).findAll("td").at(1).find("abbr").attributes().title).toBe("3 +1 / -2");
         expect(rows.at(1).findAll("td").at(2).find("abbr").text()).toBe("3.3k"); // costs per case averted
-        expect(rows.at(1).findAll("td").at(2).find("abbr").attributes().title).toBe("3.3k +10.0k / -2.5k");
+        expect(rows.at(1).findAll("td").at(2).find("abbr").attributes().title).toBe("3.3k +6.7k / -833.3");
+
+        expect(rows.at(2).find("td").text()).toBe("display name for IRS");
+        expect(rows.at(2).findAll("td").at(1).find("abbr").text()).toBe("5"); // cases averted
+        expect(rows.at(2).findAll("td").at(1).find("abbr").attributes().title).toBe("5 +3 / -0");
+        expect(rows.at(2).findAll("td").at(2).find("abbr").text()).toBe("2.0k"); // costs per case averted
+        expect(rows.at(2).findAll("td").at(2).find("abbr").attributes().title).toBe("2.0k +0.0 / -750.0");
+
     });
 });

--- a/src/app/static/src/tests/components/figures/errorInterval.test.ts
+++ b/src/app/static/src/tests/components/figures/errorInterval.test.ts
@@ -1,0 +1,14 @@
+import {getErrorInterval} from "../../../app/components/figures/errorInterval";
+
+describe("error intervals", () => {
+
+    it("correctly calculates interval", () => {
+        expect(getErrorInterval(2, 3, 6)).toEqual({plus: 3, minus: 1});
+    });
+
+    it("correctly expands interval to include mean", () => {
+        expect(getErrorInterval(2, 6, 3)).toEqual({plus: 0, minus: 4});
+        expect(getErrorInterval(2, 1, 6)).toEqual({plus: 5, minus: 0});
+    });
+
+});

--- a/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
@@ -204,8 +204,8 @@ describe("long format data series", () => {
             data: [
                 {"month": 1, "intervention": "none", "value": 0.1},
                 {"month": 2, "intervention": "none", "value": 0.3},
-                {"month": 1, "intervention": "ITN",  "value": 0.5, "error_plus": 0.05, "error_minus": 0.06},
-                {"month": 2, "intervention": "ITN", "value": 0.7, "error_plus": 0.07, "error_minus": 0.08},
+                {"month": 1, "intervention": "ITN",  "value": 0.5, "error_plus": 1.25, "error_minus": 0.5},
+                {"month": 2, "intervention": "ITN", "value": 0.7, "error_plus": 3, "error_minus": 3},
             ],
             settings: null
         };
@@ -227,8 +227,8 @@ describe("long format data series", () => {
                 type: "data",
                 col: "error_plus",
                 colminus: "error_minus",
-                array: [0.05, 0.07],
-                arrayminus: [0.06, 0.08]
+                array: [0.25, 1],
+                arrayminus: [0.5, 0]
             }
         });
     });

--- a/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
@@ -123,7 +123,9 @@ describe("wide format data series", () => {
         const localProps = {
             ...props,
             series: [{
-                id: "ITN", x: ["ITN"], error_y: {
+                id: "ITN",
+                x: ["ITN"],
+                error_y: {
                     cols: ["cases_averted_high"],
                     colsminus: ["cases_averted_low"]
                 }
@@ -131,7 +133,6 @@ describe("wide format data series", () => {
         }
         const dataSeries = useWideFormatData(localProps).dataSeries.value;
         expect(dataSeries.length).toBe(1);
-
         expect(dataSeries[0]).toEqual({
             id: "ITN",
             x: ["ITN"],
@@ -139,10 +140,31 @@ describe("wide format data series", () => {
             error_y: {
                 cols: ["cases_averted_high"],
                 colsminus: ["cases_averted_low"],
-                array: [110],
-                arrayminus: [90]
+                array: [10],
+                arrayminus: [10]
             }
         });
+    });
+
+    it("extends error bars as necessary", () => {
+        const localProps = {
+            ...props,
+            series: [{
+                id: "ITN",
+                x: ["ITN"],
+                error_y: {
+                    cols: ["cases_averted_high"],
+                    colsminus: ["cases_averted_low"]
+                }
+            }],
+            data: [
+                {"int": "ITN", "net_use": 0, "cases_averted": 80, "cases_averted_low": 90, "cases_averted_high": 110},
+            ],
+        }
+        const dataSeries = useWideFormatData(localProps).dataSeries.value;
+        expect(dataSeries.length).toBe(1);
+        expect(dataSeries[0].error_y.array).toEqual([30]);
+        expect(dataSeries[0].error_y.arrayminus).toEqual([0]);
     });
 
     it("uses formulae if provided", () => {
@@ -181,7 +203,9 @@ describe("wide format data series", () => {
         const localProps = {
             ...props,
             series: [{
-                id: "ITN", x: ["ITN"], error_y: {
+                id: "ITN",
+                x: ["ITN"],
+                error_y: {
                     cols: ["{cases_averted_high} * 2"],
                     colsminus: ["{cases_averted_low} / 2"]
                 }
@@ -197,8 +221,8 @@ describe("wide format data series", () => {
             error_y: {
                 cols: ["{cases_averted_high} * 2"],
                 colsminus: ["{cases_averted_low} / 2"],
-                array: [220],
-                arrayminus: [45]
+                array: [120],
+                arrayminus: [55]
             }
         });
     });


### PR DESCRIPTION
Ensure that error intervals always include low, mean and high confidence values. This ensures that error lines in the bar and line charts are rendered correctly, as well as tooltips in the tables.
## Old vs new
![Screenshot from 2021-01-22 08-45-24](https://user-images.githubusercontent.com/1724545/105467932-3dfc7a00-5c8e-11eb-9d2d-d54b116c533b.png)
![Screenshot from 2021-01-22 08-43-29](https://user-images.githubusercontent.com/1724545/105467928-3d63e380-5c8e-11eb-8f34-9ce21612459c.png)
![Screenshot from 2021-01-22 08-43-44](https://user-images.githubusercontent.com/1724545/105468009-5371a400-5c8e-11eb-9246-61f9bd6e2f52.png)
![Screenshot from 2021-01-22 08-44-01](https://user-images.githubusercontent.com/1724545/105468005-52d90d80-5c8e-11eb-9a38-d61efc7f64fa.png)
