### PR TITLE
mrc-2106 Add ability to transform table values prior to formatting

### DIFF
--- a/src/app/static/src/app/components/figures/dynamicTable.vue
+++ b/src/app/static/src/app/components/figures/dynamicTable.vue
@@ -19,6 +19,7 @@
     import {FilteringProps, useFiltering} from "./filteredData";
     import {useTransformation} from "./transformedData";
     import numeral from "numeral";
+    import {evaluate} from "mathjs/number";
     import {ColumnDefinition} from "../../generated";
 
     interface Props extends FilteringProps {
@@ -46,8 +47,11 @@
                     }
                     value = parseFloat(value);
                 }
+                if (col.transform) {
+                    value = evaluate(col.transform.replace(/{}/g, value.toString()));
+                }
                 if (col.precision) {
-                    value = value.toPrecision(col.precision)
+                    value = (<number>value).toPrecision(col.precision)
                 }
                 if (col.format) {
                     value = numeral(value).format(col.format)

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -10,6 +10,7 @@ export type Data = {
 export interface DataOptions {
   [k: string]: any;
 }
+export type Docs = string;
 export interface DynamicFormOptions {
   controlSections: ControlSection[];
 }
@@ -17,6 +18,8 @@ export interface ControlSection {
   label: string;
   description?: string;
   controlGroups: ControlGroup[];
+  documentation?: string;
+  collapsible?: boolean;
 }
 export interface ControlGroup {
   label?: string;
@@ -36,6 +39,7 @@ export interface SelectControl {
       [k: string]: any;
     }[];
   }[];
+  excludeNullOption?: boolean;
 }
 export interface NumberControl {
   name: string;
@@ -107,6 +111,7 @@ export interface ColumnDefinition {
   valueTransform?: {
     [k: string]: any;
   };
+  transform?: string;
   format?: string;
   precision?: number;
 }

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -100,13 +100,13 @@ describe("dynamic table", () => {
         });
         const headers = wrapper.findAll("th");
         expect(headers.length).toBe(7);
-        expect(headers.at(0).text()).toBe("Intervention");
-        expect(headers.at(1).text()).toBe("Net use");
-        expect(headers.at(2).text()).toBe("Cases averted");
-        expect(headers.at(3).text()).toBe("Prevalence");
-        expect(headers.at(4).text()).toBe("Total costs");
-        expect(headers.at(5).text()).toBe("Cost per case averted");
-        expect(headers.at(6).text()).toBe("Cost per 1000 cases averted");
+        expect(headers.at(0).text()).toContain("Intervention");
+        expect(headers.at(1).text()).toContain("Net use");
+        expect(headers.at(2).text()).toContain("Cases averted");
+        expect(headers.at(3).text()).toContain("Prevalence");
+        expect(headers.at(4).text()).toContain("Total costs");
+        expect(headers.at(5).text()).toContain("Cost per case averted");
+        expect(headers.at(6).text()).toContain("Cost per 1000 cases averted");
     });
 
     it("filters rows by settings", () => {

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -10,25 +10,29 @@ describe("dynamic table", () => {
             "intervention": "none",
             "net_use": "n/a",
             "cases_averted": 0,
-            "prev": 0.111
+            "prev": 0.111,
+            "cases_averted_per_1000": 0
         },
         {
             "intervention": "none",
             "net_use": "0.4",
             "cases_averted": 0,
-            "prev": 0.222
+            "prev": 0.222,
+            "cases_averted_per_1000": 0
         },
         {
             "intervention": "ITN",
             "net_use": "0.2",
             "cases_averted": 3,
-            "prev": 0.311
+            "prev": 0.311,
+            "cases_averted_per_1000": 32
         },
         {
             "intervention": "ITN",
             "net_use": "0.4",
             "cases_averted": 3,
-            "prev": 0.411
+            "prev": 0.411,
+            "cases_averted_per_1000": 37
         }];
 
     const config: ColumnDefinition[] = [
@@ -70,6 +74,16 @@ describe("dynamic table", () => {
                 "ITN": "({population} * {procure_people_per_net} * 2)/{cases_averted}",
             },
             format: "0.0a"
+        },
+        {
+            displayName: "Cost per 1000 cases averted",
+            valueCol: "intervention",
+            valueTransform: {
+                "none": "({population} * {procure_people_per_net}) / {cases_averted_per_1000}",
+                "ITN": "({population} * {procure_people_per_net} * 2) / {cases_averted_per_1000}",
+            },
+            transform: "round({} / 10) * 10",
+            format: "0"
         }
     ];
 
@@ -84,13 +98,14 @@ describe("dynamic table", () => {
             propsData: {data, config, settings}
         });
         const headers = wrapper.findAll("th");
-        expect(headers.length).toBe(6);
+        expect(headers.length).toBe(7);
         expect(headers.at(0).text()).toBe("Intervention");
         expect(headers.at(1).text()).toBe("Net use");
         expect(headers.at(2).text()).toBe("Cases averted");
         expect(headers.at(3).text()).toBe("Prevalence");
         expect(headers.at(4).text()).toBe("Total costs");
         expect(headers.at(5).text()).toBe("Cost per case averted");
+        expect(headers.at(6).text()).toBe("Cost per 1000 cases averted");
     });
 
     it("filters rows by settings", () => {
@@ -116,6 +131,7 @@ describe("dynamic table", () => {
         expect(rows.at(0).findAll("td").at(3).text()).toBe("0.11"); // prev
         expect(rows.at(0).findAll("td").at(4).text()).toBe("5k"); // total costs
         expect(rows.at(0).findAll("td").at(5).text()).toBe("n/a"); // costs per case averted
+        expect(rows.at(0).findAll("td").at(6).text()).toBe("n/a"); // costs per 1000 cases averted
 
         expect(rows.at(1).find("td").text()).toBe("display name for ITN");
         expect(rows.at(1).findAll("td").at(1).text()).toBe("0.2"); // net use
@@ -123,6 +139,7 @@ describe("dynamic table", () => {
         expect(rows.at(1).findAll("td").at(3).text()).toBe("0.31"); // prev
         expect(rows.at(1).findAll("td").at(4).text()).toBe("10k"); // total costs
         expect(rows.at(1).findAll("td").at(5).text()).toBe("3.3k"); // costs per case averted
+        expect(rows.at(1).findAll("td").at(6).text()).toBe("310"); // costs per 1000 cases averted
     });
 
 });

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-2106
+master

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2106


### PR DESCRIPTION
This is a simplification of changes previously made to address mrc-2089 (see #73 and mrc-ide/mintr#36), as discussed [here](https://github.com/mrc-ide/mintr/pull/36#issuecomment-756630261). It requires mrc-ide/mintr#40.

It adds `ColumnDefinition.transform`, which is an optional formula applied before `precision` and `format`. It is intended to be a transformation common to the results of any `valueTransform` where scaling or rounding is necessary. It is distinct from formatting options as it actually modifies the relevant value. It is only possible to refer to the value in question, not any other element of the row in which it appears (hence the anonymous `{}` identifier).

This approach means that the backend doesn't need to be aware of such transforms i.e. the changes to tests introduced in mrc-ide/mintr#36 are no longer necessary.

This PR requires new type definitions, which pulls in some unrelated (previously unincorporated?) changes.