### PR TITLE
mrc-2101 Support custom 'series' rangemode

### DIFF
--- a/src/app/static/README.md
+++ b/src/app/static/README.md
@@ -25,3 +25,19 @@ directory
 - js is bundled using webpack - this task can be triggered by running `npm run js`
 
 Or to compile both at once, `npm run build`
+
+### Plotly Configuration
+
+MINT supports definition of graph layouts using [plotly.js](https://plotly.com/javascript/), and adds several possible customisations. 
+The configurations themselves are provided from the [inst/json](https://github.com/mrc-ide/mintr/tree/master/inst/json) folder in mintr.  
+
+Supported customisations are :
+
+#### rangemode: "series"
+
+This custom rangemode may be applied to the layout's `xaxis` or `yaxis`. It behaves similarly to plotly's autorange behaviour
+but does not include shape values in the calculated default range, so that the shape line drawn for zonal budget will only 
+be visible in the default range if it is not greater than any of the series values. The max of the calculated range is
+the max series value plus 2% padding. The min is the lower of 0 and the min series value.  
+
+

--- a/src/app/static/src/app/components/figures/graphs/layout.ts
+++ b/src/app/static/src/app/components/figures/graphs/layout.ts
@@ -23,7 +23,7 @@ function evaluateShapes(layout: Layout, props: Props) {
         layout.shapes.map((shape: any, index: number) => {
             if (shape.type == "line" && shape.y_formula) {
                 const y = evaluateFormula(shape.y_formula);
-                if (y === "undefined") {
+                if (typeof y === "undefined") {
                     toRemove.push(index)
                 } else {
                     shape.y0 = y;

--- a/src/app/static/src/app/components/figures/graphs/layout.ts
+++ b/src/app/static/src/app/components/figures/graphs/layout.ts
@@ -19,13 +19,20 @@ function evaluateShapes(layout: Layout, props: Props) {
     const {evaluateFormula} = useTransformation(props);
     // Currently supports transformation to horizontal line only
     if (layout.shapes) {
-        layout.shapes.map((shape: any) => {
+        const toRemove: number[] = [];
+        layout.shapes.map((shape: any, index: number) => {
             if (shape.type == "line" && shape.y_formula) {
-                const y = evaluateFormula(shape.y_formula) || 0;
-                shape.y0 = y;
-                shape.y1 = y;
+                const y = evaluateFormula(shape.y_formula);
+                if (y === "undefined") {
+                    toRemove.push(index)
+                } else {
+                    shape.y0 = y;
+                    shape.y1 = y;
+                }
             }
         });
+
+        toRemove.reverse().map((i: number) => {layout.shapes!!.splice(i, 1);});
     }
 }
 
@@ -34,7 +41,7 @@ function evaluateRanges(layout: Layout, dataSeries: readonly SeriesDefinition[])
     //to max series value (exclude shapes)
 
     const evaluateRangeForAxis = function(axis: Axis | undefined, dataKey: string) {
-        if (axis && axis.rangemode == "series") {
+        if (axis && axis.rangemode === "series") {
             axis.autorange = false;
 
             const data: number[] = [];

--- a/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
@@ -51,7 +51,7 @@ export function useLongFormatData(props: Props) {
     };
 
     const dataSeries = computed(() => {
-        const result: any[] = []
+        const result: SeriesDefinition[] = []
         props.series.map((d: SeriesDefinition) => {
             if (d.x && d.y) {
                 // all values are given explicitly

--- a/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
+++ b/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
@@ -5,19 +5,18 @@
 </template>
 <script lang="ts">
     import Plotly from "./plotly/Plotly.vue"
-    import {computed, defineComponent, ref} from "@vue/composition-api";
+    import {computed, defineComponent, Ref, ref} from "@vue/composition-api";
     import {FilteringProps} from "../filteredData";
     import {useLongFormatData} from "./longFormatDataSeries";
     import {useWideFormatData} from "./wideFormatDataSeries";
     import {setupHoverBelowObserver} from "./hoverBelow";
-    import {Dictionary} from "vue-router/types/router";
-    import {LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
+    import {Layout, LongFormatMetadata, SeriesDefinition, WideFormatMetadata} from "../../../generated";
     import {useLayout} from "./layout";
 
     interface Props extends FilteringProps {
         series: SeriesDefinition[]
         metadata: WideFormatMetadata | LongFormatMetadata
-        layout: Dictionary<any>
+        layout: Layout
     }
 
     export default defineComponent({
@@ -33,22 +32,22 @@
                 setupHoverBelowObserver(observer, "hoverbelow");
             }
 
-            let dataSeries = null;
+            let dataSeries: Ref<readonly SeriesDefinition[]>;
             if (props.metadata.format == "long") {
-                dataSeries = useLongFormatData(props).dataSeries
+                dataSeries = useLongFormatData(props).dataSeries;
             } else {
-                dataSeries = useWideFormatData(props).dataSeries
+                dataSeries = useWideFormatData(props).dataSeries;
             }
 
-            const transformedLayout = computed<any>(() => ({
-                ...useLayout(props),
+            const transformedLayout = computed(() => ({
+                ...useLayout(props, dataSeries.value),
                 font: {
                     // use the same font settings as Bootstrap, which the rest of the app uses
                     family: '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"',
                     size: '1rem',
                     color: '#212529'
                 }
-            }))
+            }));
 
             return {
                 transformedLayout,

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -72,7 +72,7 @@ export interface LongFormatMetadata {
   settings?: string[];
 }
 export interface WideFormatMetadata {
-  cols: string[];
+  cols?: string[];
   id_col: string;
   format: "wide";
   settings?: string[];
@@ -87,8 +87,8 @@ export interface SeriesDefinition {
   [k: string]: any;
 }
 export interface Layout {
-  xaxis?: Axis;
-  yaxis?: Axis;
+  xaxis: Axis;
+  yaxis: Axis;
   shapes?: {
     type?: string;
     y_formula?: string;
@@ -101,6 +101,7 @@ export interface Layout {
   [k: string]: any;
 }
 export interface Axis {
+  title?: string;
   autorange?: boolean;
   rangemode?: string;
   range?: number[];
@@ -129,6 +130,7 @@ export interface ColumnDefinition {
   valueTransform?: {
     [k: string]: any;
   };
+  transform?: string;
   format?: string;
   precision?: number;
 }

--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -10,6 +10,7 @@ export type Data = {
 export interface DataOptions {
   [k: string]: any;
 }
+export type Docs = string;
 export interface DynamicFormOptions {
   controlSections: ControlSection[];
 }
@@ -17,6 +18,8 @@ export interface ControlSection {
   label: string;
   description?: string;
   controlGroups: ControlGroup[];
+  documentation?: string;
+  collapsible?: boolean;
 }
 export interface ControlGroup {
   label?: string;
@@ -36,6 +39,7 @@ export interface SelectControl {
       [k: string]: any;
     }[];
   }[];
+  excludeNullOption?: boolean;
 }
 export interface NumberControl {
   name: string;
@@ -55,9 +59,7 @@ export interface ErrorDetail {
 export interface Graph {
   metadata: LongFormatMetadata | WideFormatMetadata;
   series: SeriesDefinition[];
-  layout: {
-    [k: string]: any;
-  };
+  layout: Layout;
   config?: {
     [k: string]: any;
   };
@@ -82,6 +84,26 @@ export interface SeriesDefinition {
   id?: string;
   name?: string;
   type?: string;
+  [k: string]: any;
+}
+export interface Layout {
+  xaxis?: Axis;
+  yaxis?: Axis;
+  shapes?: {
+    type?: string;
+    y_formula?: string;
+    x0?: number;
+    x1?: number;
+    y0?: number;
+    y1?: number;
+    [k: string]: any;
+  }[];
+  [k: string]: any;
+}
+export interface Axis {
+  autorange?: boolean;
+  rangemode?: string;
+  range?: number[];
   [k: string]: any;
 }
 export interface ResponseFailure {

--- a/src/app/static/src/tests/components/costEffectiveness.test.ts
+++ b/src/app/static/src/tests/components/costEffectiveness.test.ts
@@ -40,7 +40,8 @@ describe("costPerCase", () => {
         const state = {
             costPerCaseGraphConfig:  mockGraph({
                 layout: {
-                    whatever: 1
+                    xaxis: {title: "x1"},
+                    yaxis: {title: "y1"}
                 },
                 series: [{
                     id: "none"
@@ -54,7 +55,8 @@ describe("costPerCase", () => {
             }),
             costCasesGraphConfig:  mockGraph({
                 layout: {
-                    whatever: 2
+                    xaxis: {title: "x2"},
+                    yaxis: {title: "y2"}
                 },
                 series: [{
                     id: "none"

--- a/src/app/static/src/tests/components/figures/layout.test.ts
+++ b/src/app/static/src/tests/components/figures/layout.test.ts
@@ -3,66 +3,156 @@ import {useLayout} from "../../../app/components/figures/graphs/layout";
 describe("layout", () => {
     const settings = {zonal_budget: 1000};
 
-    it("set y values for line shapes where y_formula is set", () => {
-        const layout = {
-            shapes: [
-                {
-                    type: "line",
-                    y_formula: "{zonal_budget}",
-                    x0: 0,
-                    x1: 1
-                },
-                {
-                    type: "line",
-                    y_formula: "{zonal_budget} * 2",
-                    x0: 0,
-                    x1: 2
-                }
-            ]
-        };
+    describe("evaluate shapes", () => {
 
-        const transformedLayout = useLayout({layout, settings});
-        expect(transformedLayout.shapes).toStrictEqual([
-            {...layout.shapes[0], y0: 1000, y1: 1000},
-            {...layout.shapes[1], y0: 2000, y1: 2000}
-        ]);
+        it("sets y values for line shapes where y_formula is set", () => {
+            const layout = {
+                shapes: [
+                    {
+                        type: "line",
+                        y_formula: "{zonal_budget}",
+                        x0: 0,
+                        x1: 1
+                    },
+                    {
+                        type: "line",
+                        y_formula: "{zonal_budget} * 2",
+                        x0: 0,
+                        x1: 2
+                    }
+                ]
+            };
+
+            const transformedLayout = useLayout({layout, settings}, []);
+            expect(transformedLayout.shapes).toStrictEqual([
+                {...layout.shapes[0], y0: 1000, y1: 1000},
+                {...layout.shapes[1], y0: 2000, y1: 2000}
+            ]);
+        });
+
+        it("sets y values to 0 when evaluation is undefined", () => {
+            const layout = {
+                shapes: [
+                    {
+                        type: "line",
+                        y_formula: "{zonal_budget}",
+                        x0: 0,
+                        x1: 1
+                    }
+                ]
+            };
+
+            const transformedLayout = useLayout({layout, settings: {}}, []);
+            expect(transformedLayout.shapes).toStrictEqual([
+                {...layout.shapes[0], y0: 0, y1: 0}
+            ]);
+        });
+
+        it("does not update non-line shapes", () => {
+            const layout = {
+                shapes: [
+                    {
+                        type: "line",
+                        y_formula: "{zonal_budget}",
+                    },
+                    {
+                        type: "rect",
+                        y_formula: "{zonal_budget} * 2"
+                    }
+                ]
+            };
+
+            const transformedLayout = useLayout({layout, settings}, []);
+            expect(transformedLayout.shapes).toStrictEqual([
+                {...layout.shapes[0], y0: 1000, y1: 1000},
+                {...layout.shapes[1]}
+            ]);
+        });
+
+        it("does nothing when y_formula is not set", () => {
+            const layout = {
+                shapes: [
+                    {
+                        type: "line",
+                        x0: 0,
+                        x1: 1,
+                        y0: 100,
+                        y1: 200
+                    }
+                ]
+            };
+
+            const transformedLayout = useLayout({layout, settings}, []);
+            expect(transformedLayout).toStrictEqual(layout);
+        });
+
     });
 
-    it("does not update non-line shapes", () => {
-        const layout = {
-            shapes: [
-                {
-                    type: "line",
-                    y_formula: "{zonal_budget}",
+    describe("evaluate ranges", () => {
+        it("evaluates series range for y axis", () => {
+            const layout = {
+                yaxis: {
+                    rangemode: "series",
+                    autorange: true,
+                }
+            };
+            const series = [
+                {y: [10,100,50]},
+                {y: [1,2,3]}
+            ];
+            const transformedLayout = useLayout({layout, settings}, series);
+            expect(transformedLayout.yaxis.autorange).toBe(false);
+            expect(transformedLayout.yaxis.range).toStrictEqual([0, 102]);
+        });
+
+        it("evaluates series range for x axis", () => {
+            const layout = {
+                xaxis: {
+                    rangemode: "series",
+                    autorange: true,
+                }
+            };
+            const series = [
+                {x: [0,1,2]},
+                {x: [10,200,50]}
+            ];
+            const transformedLayout = useLayout({layout, settings}, series);
+            expect(transformedLayout.xaxis.autorange).toBe(false);
+            expect(transformedLayout.xaxis.range).toStrictEqual([0, 204]);
+        });
+
+        it("if there are  negative values, sets min to lowest", () => {
+            const layout = {
+                yaxis: {
+                    rangemode: "series",
+                    autorange: true,
+                }
+            };
+            const series = [
+                {y: [10,90,-5]},
+                {y: [1,2,3,-10]}
+            ];
+            const transformedLayout = useLayout({layout, settings}, series);
+            expect(transformedLayout.yaxis.autorange).toBe(false);
+            expect(transformedLayout.yaxis.range).toStrictEqual([-10, 92]);
+        });
+
+        it("does nothing if rangemode is not 'series'", () => {
+            const layout = {
+                yaxis: {
+                    rangemode: "tozero",
+                    autorange: true,
                 },
-                {
-                    type: "rect",
-                    y_formula: "{zonal_budget} * 2"
+                xaxis: {
+                    autorange: true
                 }
-            ]
-        };
-
-        const transformedLayout = useLayout({layout, settings});
-        expect(transformedLayout.shapes).toStrictEqual([
-            {...layout.shapes[0], y0: 1000, y1: 1000},
-            {...layout.shapes[1]}
-        ]);
-    });
-
-    it("does nothing when y_formula is not set", () => {
-        const layout = {
-            shapes: [
-                {
-                    type: "line",
-                    x0: 0,
-                    x1: 1,
-                    y0: 100,
-                    y1: 200
-                }
-            ]
-        };
-
-        const transformedLayout = useLayout({layout, settings});
-        expect(transformedLayout).toStrictEqual(layout);
+            };
+            const series = [
+                {x: [0], y: [1]}
+            ];
+            const transformedLayout = useLayout({layout, settings}, series);
+            expect(transformedLayout.yaxis).toStrictEqual({rangemode: "tozero", autorange: true});
+            expect(transformedLayout.xaxis).toStrictEqual({autorange: true});
+        });
     });
 });

--- a/src/app/static/src/tests/components/figures/layout.test.ts
+++ b/src/app/static/src/tests/components/figures/layout.test.ts
@@ -21,7 +21,7 @@ describe("layout", () => {
                         x1: 2
                     }
                 ]
-            };
+            } as any;
 
             const transformedLayout = useLayout({layout, settings}, []);
             expect(transformedLayout.shapes).toStrictEqual([
@@ -30,9 +30,15 @@ describe("layout", () => {
             ]);
         });
 
-        it("sets y values to 0 when evaluation is undefined", () => {
+        it("removes shapes when evaluation is undefined", () => {
             const layout = {
                 shapes: [
+                    {
+                        type: "line",
+                        y_formula: "{not_a_setting}",
+                        x0: 0,
+                        x1: 1
+                    },
                     {
                         type: "line",
                         y_formula: "{zonal_budget}",
@@ -40,11 +46,11 @@ describe("layout", () => {
                         x1: 1
                     }
                 ]
-            };
+            } as any;
 
-            const transformedLayout = useLayout({layout, settings: {}}, []);
+            const transformedLayout = useLayout({layout, settings}, []);
             expect(transformedLayout.shapes).toStrictEqual([
-                {...layout.shapes[0], y0: 0, y1: 0}
+                {...layout.shapes[1], y0: 1000, y1: 1000}
             ]);
         });
 
@@ -60,7 +66,7 @@ describe("layout", () => {
                         y_formula: "{zonal_budget} * 2"
                     }
                 ]
-            };
+            } as any;
 
             const transformedLayout = useLayout({layout, settings}, []);
             expect(transformedLayout.shapes).toStrictEqual([
@@ -80,7 +86,7 @@ describe("layout", () => {
                         y1: 200
                     }
                 ]
-            };
+            } as any;
 
             const transformedLayout = useLayout({layout, settings}, []);
             expect(transformedLayout).toStrictEqual(layout);
@@ -95,7 +101,7 @@ describe("layout", () => {
                     rangemode: "series",
                     autorange: true,
                 }
-            };
+            } as any;
             const series = [
                 {y: [10,100,50]},
                 {y: [1,2,3]}
@@ -111,7 +117,7 @@ describe("layout", () => {
                     rangemode: "series",
                     autorange: true,
                 }
-            };
+            } as any;
             const series = [
                 {x: [0,1,2]},
                 {x: [10,200,50]}
@@ -127,7 +133,7 @@ describe("layout", () => {
                     rangemode: "series",
                     autorange: true,
                 }
-            };
+            } as any;
             const series = [
                 {y: [10,90,-5]},
                 {y: [1,2,3,-10]}
@@ -146,7 +152,7 @@ describe("layout", () => {
                 xaxis: {
                     autorange: true
                 }
-            };
+            } as any;
             const series = [
                 {x: [0], y: [1]}
             ];

--- a/src/app/static/src/tests/components/impact.test.ts
+++ b/src/app/static/src/tests/components/impact.test.ts
@@ -22,8 +22,9 @@ describe("impact", () => {
             currentProject: project,
             prevalenceGraphConfig: mockGraph({
                 layout: {
-                    whatever: 1
-                },
+                    xaxis: {title: "x"},
+                    yaxis: {title: "y"}
+                } ,
                 series: [{
                     x: [1, 2],
                     y: [100, 200]
@@ -38,7 +39,10 @@ describe("impact", () => {
         const wrapper = shallowMount(impact, {propsData: {activeTab: "Graphs"}, store});
         expect(wrapper.findAll(plotlyGraph).length).toBe(1);
         const graph = wrapper.findAll(plotlyGraph).at(0);
-        expect(graph.props("layout")).toEqual({whatever: 1});
+        expect(graph.props("layout")).toEqual({
+            xaxis: {title: "x"},
+            yaxis: {title: "y"}
+        });
         expect(graph.props("metadata")).toEqual({
             format: "wide",
             id_col: "intervention",
@@ -60,7 +64,8 @@ describe("impact", () => {
             currentProject: project,
             casesGraphConfig: mockGraph({
                 layout: {
-                    whatever: 1
+                    xaxis: {title: "x"},
+                    yaxis: {title: "y"}
                 },
                 series: [{
                     x: [1, 2],
@@ -76,7 +81,10 @@ describe("impact", () => {
         const wrapper = shallowMount(impact, {propsData: {activeTab: "Graphs"}, store});
         expect(wrapper.findAll(plotlyGraph).length).toBe(1);
         const graph = wrapper.findAll(plotlyGraph).at(0);
-        expect(graph.props("layout")).toEqual({whatever: 1});
+        expect(graph.props("layout")).toEqual({
+            xaxis: {title: "x"},
+            yaxis: {title: "y"}
+        });
         expect(graph.props("metadata")).toEqual({
             format: "wide",
             id_col: "intervention",

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -27,7 +27,10 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
 export function mockGraph(props: Partial<Graph> = {}): Graph {
     return {
         series: [],
-        layout: {},
+        layout: {
+            xaxis: {title: "x"},
+            yaxis: {title: "y"}
+        },
         metadata: {
             format: "wide",
             id_col: "intervention",

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2101


### PR DESCRIPTION
- Implements 'series' rangemode in `layout.ts` allowing zonal budget line to fall outside default range
- Targets mintr branch https://github.com/mrc-ide/mintr/pull/41 which sets this rangemode configuration
- Updates generated interface types from the enhanced schema definitions in the mintr branch
- Fixes a bug where zonal budget line was drawn as a weird diagonal if field value was cleared by user - just needed to be defensive about evaluating to undefined. 
- Added some README documentation about the new customisation - there is a separate ticket to document the existing customisations