### PR TITLE
mrc-2019 Add error bars to cost per case averted barchart

### DIFF
--- a/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/wideFormatDataSeries.ts
@@ -19,8 +19,8 @@ export function useWideFormatData(props: Props) {
     const getErrorBar = (row: any, error: any) => {
         return {
             ...error,
-            array: error.cols.map((c: string) => row[c]),
-            arrayminus: error.colsminus.map((c: string) => row[c])
+            array: error.cols.map((c: string) => c.match(/\{\w+\}/) ? evaluateFormula(c, row) : row[c]),
+            arrayminus: error.colsminus.map((c: string) => c.match(/\{\w+\}/) ? evaluateFormula(c, row) : row[c])
         }
     }
     const dataSeries = computed(() => {

--- a/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
@@ -176,4 +176,30 @@ describe("wide format data series", () => {
             y_formula: ["{cases_averted_high} - {cases_averted}"]
         });
     });
+
+    it("uses error formulae if provided", () => {
+        const localProps = {
+            ...props,
+            series: [{
+                id: "ITN", x: ["ITN"], error_y: {
+                    cols: ["{cases_averted_high} * 2"],
+                    colsminus: ["{cases_averted_low} / 2"]
+                }
+            }]
+        }
+        const dataSeries = useWideFormatData(localProps).dataSeries.value;
+        expect(dataSeries.length).toBe(1);
+
+        expect(dataSeries[0]).toEqual({
+            id: "ITN",
+            x: ["ITN"],
+            y: [100],
+            error_y: {
+                cols: ["{cases_averted_high} * 2"],
+                colsminus: ["{cases_averted_low} / 2"],
+                array: [220],
+                arrayminus: [45]
+            }
+        });
+    });
 });

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2109

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-2109
+master


### PR DESCRIPTION
Allow error bars to be generated using formulae

Formulae themselves (and relevant data) provided by mrc-ide/mintr#44

![Screenshot from 2021-01-13 14-20-24](https://user-images.githubusercontent.com/1724545/104464211-948cf880-55aa-11eb-8c26-7f40bf48117b.png)