### PR TITLE
mrc-2120 Fix sporadic integration test failures

### DIFF
--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -108,6 +108,8 @@ describe("actions", () => {
         expect(Object.keys(firstRow).sort())
             .toEqual([
                 "casesAverted",
+                "casesAvertedErrorMinus",
+                "casesAvertedErrorPlus",
                 "casesAvertedPer1000",
                 "casesAvertedPer1000ErrorMinus",
                 "casesAvertedPer1000ErrorPlus",
@@ -146,8 +148,7 @@ describe("actions", () => {
         const commit = jest.fn();
         await (actions[RootAction.FetchDocs] as any)({commit} as any);
 
-        expect(commit.mock.calls[0][0]).toBe(RootMutation.UpdateImpactDocs);
-        expect(commit.mock.calls[1][0]).toBe(RootMutation.UpdateCostDocs);
+        expect(new Set(commit.mock.calls.map(call => call[0]))).toEqual(new Set([RootMutation.UpdateImpactDocs, RootMutation.UpdateCostDocs]));
         expect(commit.mock.calls[0][1]).toContain("<ul>");
         expect(commit.mock.calls[1][1]).toContain("<ul>");
 


### PR DESCRIPTION
- Remove assumption regarding ordering of independent HTTP requests
- Fix other test that was failing because integration tests weren't running automatically 