### PR TITLE
Prevent cost-per-case-averted error bars containing negative values

### DIFF
--- a/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
+++ b/src/app/static/src/app/components/figures/graphs/longFormatDataSeries.ts
@@ -31,7 +31,11 @@ export function useLongFormatData(props: Props) {
                 }
 
                 if (error_col && error_col_minus) {
-                    error_array.push(getErrorInterval(row[error_col_minus], row[meta.x_col], row[error_col]));
+                    error_array.push(getErrorInterval(
+                        evaluateFormula(error_col_minus, row),
+                        row[meta.x_col],
+                        evaluateFormula(error_col, row)
+                    ));
                 }
             }
         });

--- a/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
@@ -196,8 +196,8 @@ describe("long format data series", () => {
                     id: "ITN",
                     error_x: {
                         type: "data",
-                        col: "error_plus",
-                        colminus: "error_minus"
+                        col: "{error_plus}",
+                        colminus: "{error_minus}"
                     }
                 }
             ],
@@ -225,8 +225,8 @@ describe("long format data series", () => {
             y: [0.5, 0.7],
             error_x: {
                 type: "data",
-                col: "error_plus",
-                colminus: "error_minus",
+                col: "{error_plus}",
+                colminus: "{error_minus}",
                 array: [0.25, 1],
                 arrayminus: [0.5, 0]
             }

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2186


### PR DESCRIPTION
It's currently possible for error bars to cross the x- or y-axis (depending on the chart) as a result of negative confidence values in the source data. This changeset and it's pre-requisite mrc-ide/mintr#53 ensure that the error bars for costs don't fall below zero - see screenshot below (also running on https://mint-dev.dide.ic.ac.uk/).

The change in mintr applies to both lower and upper confidence values because for small values these are sometimes reversed (i.e. the upper value is actually the negative one). This could be addressed in MINT instead but I'd like to establish the underlying issue (if any) with the science team first. The change in MINT applies formulae to x error values.

Note that we already apply a transformation in MINT to ensure that error bars contain the mean value (see mrc-2104), which takes precedence. However, the data that we send from mintr doesn't include any negative _mean_ values.

A much simpler fix would have been to ensure that all confidence values are positive, but this would have affected data not related to costs. I will also explain this to the science team - as a proper fix it may be that they or we need to apply more sophisticated filtering to the source data.

![Screenshot_2021-02-12 MINT(1)](https://user-images.githubusercontent.com/1724545/107797323-bc5eb000-6d52-11eb-876e-3981f0f8995b.png)
