### PR TITLE
mrc-2193 Ensure that uncertainty values are maximised

### DIFF
--- a/src/app/static/src/app/components/figures/errorInterval.ts
+++ b/src/app/static/src/app/components/figures/errorInterval.ts
@@ -5,7 +5,7 @@ interface ErrorInterval {
 
 export function getErrorInterval(low: number, mean: number, high: number): ErrorInterval {
     return {
-      plus: Math.max(high, low, mean) - mean,
-      minus: mean - Math.min(high, low, mean)
+      plus: high - mean,
+      minus: mean - low
     };
 }

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -194,7 +194,7 @@ describe("dynamic table", () => {
                 "intervention": "IRS",
                 "net_use": "0.2",
                 "cases_averted": 5,
-                "cases_averted_error_minus": 6,
+                "cases_averted_error_minus": 5,
                 "cases_averted_error_plus": 8,
                 "prev": 0.411,
                 "cases_averted_per_1000": 37

--- a/src/app/static/src/tests/components/figures/errorInterval.test.ts
+++ b/src/app/static/src/tests/components/figures/errorInterval.test.ts
@@ -6,9 +6,4 @@ describe("error intervals", () => {
         expect(getErrorInterval(2, 3, 6)).toEqual({plus: 3, minus: 1});
     });
 
-    it("correctly expands interval to include mean", () => {
-        expect(getErrorInterval(2, 6, 3)).toEqual({plus: 0, minus: 4});
-        expect(getErrorInterval(2, 1, 6)).toEqual({plus: 5, minus: 0});
-    });
-
 });

--- a/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/longFormatDataSeries.test.ts
@@ -205,7 +205,7 @@ describe("long format data series", () => {
                 {"month": 1, "intervention": "none", "value": 0.1},
                 {"month": 2, "intervention": "none", "value": 0.3},
                 {"month": 1, "intervention": "ITN",  "value": 0.5, "error_plus": 1.25, "error_minus": 0.5},
-                {"month": 2, "intervention": "ITN", "value": 0.7, "error_plus": 3, "error_minus": 3},
+                {"month": 2, "intervention": "ITN", "value": 0.7, "error_plus": 3, "error_minus": 2},
             ],
             settings: null
         };
@@ -220,9 +220,9 @@ describe("long format data series", () => {
         });
 
         expect(dataSeries[1]).toStrictEqual({
-            id: "ITN",
-            x: [1, 2],
-            y: [0.5, 0.7],
+            id: "ITN", // intervention
+            x: [1, 2], // month
+            y: [0.5, 0.7], // value
             error_x: {
                 type: "data",
                 col: "error_plus",

--- a/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
+++ b/src/app/static/src/tests/components/figures/wideFormatDataSeries.test.ts
@@ -158,7 +158,7 @@ describe("wide format data series", () => {
                 }
             }],
             data: [
-                {"int": "ITN", "net_use": 0, "cases_averted": 80, "cases_averted_low": 90, "cases_averted_high": 110},
+                {"int": "ITN", "net_use": 0, "cases_averted": 90, "cases_averted_low": 90, "cases_averted_high": 120},
             ],
         }
         const dataSeries = useWideFormatData(localProps).dataSeries.value;

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-2193
+master

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2193


### PR DESCRIPTION
Move existing logic that "stretches" confidence intervals to include the mean from the client to the server. Combined with ensuring that the "low" and "high" values are correctly ordered (without modifying their absolute values) this automatically results in uncertainty formulae being correctly calculated i.e. when we use the low value in the denominator it really is the smallest value. The mean is unmodified.

This corrective logic is now centralised within mintr and avoids having to add further workarounds to the front-end which can now assume that the confidence values are always ordered such that high >= mean >= low.

The logic is applied when loading data into the database. It could be done at the API layer so that the database stores the raw values but this would less efficient. However, this would be an easy change to make subsequently, for example if we needed the feed the raw values into the planned optimiser.

Note that this doesn't completely revert the work for mrc-2104, in particular the logic to calculate confidence intervals remains self-contained in case it has some utility in the future

Neither does it address negative values: these will be corrected at source by mrc-2206

This branch is deployed to mint-dev

Depends on mrc-ide/mintr#54