### PR TITLE
mrc-2435 Add endpoint for strategizing across regions

### DIFF
--- a/buildkite/test.sh
+++ b/buildkite/test.sh
@@ -16,6 +16,14 @@ docker build --tag=mint-test \
 
 $HERE/../scripts/run-dependencies.sh
 
+# Ensure that mintr is available
+for attempt in $(seq 30); do
+    if [[ "$(curl --silent http://localhost:8888)" == *"Welcome to mintr"* ]]; then
+        break
+    fi
+    sleep 6
+done
+
 # Run the build env image to run gradle tests
 docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/APIClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/APIClient.kt
@@ -22,6 +22,7 @@ interface APIClient {
     fun getTableData(dataOptions: Map<String, Any>): ResponseEntity<String>
     fun getImpactDocs(): ResponseEntity<String>
     fun getCostDocs(): ResponseEntity<String>
+    fun getStrategies(options: Map<String, Any>): ResponseEntity<String>
 }
 
 @Component
@@ -84,8 +85,11 @@ class MintrAPIClient(
         return get("docs/cost")
     }
 
-    fun get(url: String): ResponseEntity<String> {
+    override fun getStrategies(options: Map<String, Any>): ResponseEntity<String> {
+        return postJson("strategise", objectMapper.writeValueAsString(options))
+    }
 
+    fun get(url: String): ResponseEntity<String> {
         return "$baseUrl/$url".httpGet()
                 .addTimeouts()
                 .response()

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/StrategiseController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/StrategiseController.kt
@@ -1,0 +1,17 @@
+package org.imperial.mrc.mint.controllers
+
+import org.imperial.mrc.mint.APIClient
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/")
+class StrategiseController(private val apiClient: APIClient) {
+
+    @PostMapping("/strategise")
+    @ResponseBody
+    fun strategise(@RequestBody options: Map<String, Any>): ResponseEntity<String> {
+        return apiClient.getStrategies(options)
+    }
+
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/MintrAPIClientTests.kt
@@ -112,4 +112,31 @@ class MintrAPIClientTests {
         assertThat(result.statusCodeValue).isEqualTo(200)
         JSONValidator().validateSuccess(result.body!!, "Docs")
     }
+
+    @Test
+    fun `can get strategies`() {
+        val sut = MintrAPIClient(ConfiguredAppProperties(), ObjectMapper())
+        val options = mapOf(
+                "budget" to 20_000,
+                "zones" to listOf(
+                        mapOf(
+                                "name" to "Region A",
+                                "baselineSettings" to Settings.Baseline,
+                                "interventionSettings" to mapOf(
+                                        "procurePeoplePerNet" to 1.8,
+                                        "procureBuffer" to 7,
+                                        "priceDelivery" to 2.75,
+                                        "priceNetPBO" to 2.5,
+                                        "priceNetStandard" to 1.5,
+                                        "priceIRSPerPerson" to 5.73,
+                                        "netUse" to "0.8",
+                                        "irsUse" to "0.6"
+                                )
+                        )
+                )
+        )
+        val result = sut.getStrategies(options)
+        assertThat(result.statusCodeValue).isEqualTo(200)
+        JSONValidator().validateSuccess(result.body!!, "Strategise")
+    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
@@ -1,5 +1,6 @@
 package org.imperial.mrc.mint.integration.endpoints
 
+import org.imperial.mrc.mint.helpers.Settings
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.web.client.postForEntity
 
@@ -14,17 +15,7 @@ class StrategiseTests : EndpointTests() {
                         "zones" to listOf(
                                 mapOf(
                                         "name" to "Region A",
-                                        "baselineSettings" to mapOf(
-                                                "population" to 1000,
-                                                "seasonalityOfTransmission" to "seasonal",
-                                                "currentPrevalence" to "30%",
-                                                "bitingIndoors" to "high",
-                                                "bitingPeople" to "low",
-                                                "levelOfResistance" to "0%",
-                                                "metabolic" to "yes",
-                                                "itnUsage" to "0%",
-                                                "sprayInput" to "0%"
-                                        ),
+                                        "baselineSettings" to Settings.Baseline,
                                         "interventionSettings" to mapOf(
                                                 "procurePeoplePerNet" to 1.8,
                                                 "procureBuffer" to 7,

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
@@ -1,0 +1,45 @@
+package org.imperial.mrc.mint.integration.endpoints
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.web.client.postForEntity
+
+class StrategiseTests : EndpointTests() {
+
+    @Test
+    fun `can get strategies`() {
+        val responseEntity = testRestTemplate.postForEntity<String>(
+                "/strategise",
+                mapOf(
+                        "budget" to 20000,
+                        "zones" to listOf(
+                                mapOf(
+                                        "name" to "Region A",
+                                        "baselineSettings" to mapOf(
+                                                "population" to 1000,
+                                                "seasonalityOfTransmission" to "seasonal",
+                                                "currentPrevalence" to "30%",
+                                                "bitingIndoors" to "high",
+                                                "bitingPeople" to "low",
+                                                "levelOfResistance" to "0%",
+                                                "metabolic" to "yes",
+                                                "itnUsage" to "0%",
+                                                "sprayInput" to "0%"
+                                        ),
+                                        "interventionSettings" to mapOf(
+                                                "procurePeoplePerNet" to 1.8,
+                                                "procureBuffer" to 7,
+                                                "priceDelivery" to 2.75,
+                                                "priceNetPBO" to 2.5,
+                                                "priceNetStandard" to 1.5,
+                                                "priceIRSPerPerson" to 5.73,
+                                                "netUse" to "0.8",
+                                                "irsUse" to "0.6"
+                                        )
+                                )
+                        )
+                )
+        )
+        assertSuccess(responseEntity, "Strategise")
+    }
+
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/StrategiseControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/StrategiseControllerTests.kt
@@ -1,0 +1,28 @@
+package org.imperial.mrc.mint.unit.controllers;
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test;
+import org.imperial.mrc.mint.APIClient
+import org.imperial.mrc.mint.controllers.ImpactController
+import org.imperial.mrc.mint.controllers.StrategiseController
+import org.springframework.http.ResponseEntity
+
+class StrategiseControllerTests {
+
+    private val mockResponse = mock<ResponseEntity<String>>()
+    private val options = mapOf("option" to "value")
+
+    @Test
+    fun `gets strategies from the api`()
+    {
+        val mockAPI = mock<APIClient>{
+            on { getStrategies(options) } doReturn mockResponse
+        }
+
+        val sut = StrategiseController(mockAPI)
+        assertThat(sut.strategise(options)).isSameAs(mockResponse)
+    }
+
+}

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-2433
+master

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2433


### PR DESCRIPTION
Sorry - bit of a drip drip here but trying to keep these bite-sized. This follows-on from mrc-2433 and simply exposes the mintr endpoint via Kotlin. Can be manually invoked almost identically:
```sh
curl -s localhost:8080/strategise -H "Content-Type: application/json" -d '{"budget":20000,"zones":[{"name":"Region A","baselineSettings":{"population":1000,"seasonalityOfTransmission":"seasonal","currentPrevalence":"30%","bitingIndoors":"high","bitingPeople":"low","levelOfResistance":"0%","metabolic":"yes","itnUsage":"0%","sprayInput":"0%"},"interventionSettings":{"netUse":"0.8","irsUse":"0.6","procurePeoplePerNet":1.8,"procureBuffer":7,"priceNetStandard":1.5,"priceNetPBO":2.5,"priceDelivery":2.75,"priceIRSPerPerson":5.73,"budgetAllZones":2000000,"zonal_budget":500000.05}}]}' | jq
```
Todo:

- [x] Revert to master after mrc-ide/mintr#58