### PR TITLE
mrc-2492 Implement summary table for strategising across regions

### DIFF
--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -191,7 +191,10 @@ export const actions: ActionTree<RootState, RootState> = {
         const project = context.state.currentProject!;
         const options = {
             budget: project.budget,
-            zones: project.regions.map(({name, baselineSettings, interventionSettings}) =>
+            zones: project.regions
+                // Exclude regions that aren't fully initialised
+                .filter(region => region.interventionSettings.budgetAllZones)
+                .map(({name, baselineSettings, interventionSettings}) =>
                 ({name, baselineSettings, interventionSettings}))
         };
         await api(context)

--- a/src/app/static/src/app/actions.ts
+++ b/src/app/static/src/app/actions.ts
@@ -25,6 +25,7 @@ export enum RootAction {
     SetCurrentRegionBaselineSettings = "SetCurrentRegionBaselineSettings",
     FetchDocs = "FetchDocs",
     DismissErrors = "DismissErrors",
+    SetBudget = "SetBudget",
     Strategise = "Strategise"
 }
 
@@ -177,6 +178,11 @@ export const actions: ActionTree<RootState, RootState> = {
     [RootAction.DismissErrors](context) {
         const {commit} = context;
         commit(RootMutation.DismissErrors);
+    },
+
+    [RootAction.SetBudget](context, payload: { budget: number }) {
+        const {commit} = context;
+        commit(RootMutation.SetBudget, payload.budget);
     },
 
     async [RootAction.Strategise](context) {

--- a/src/app/static/src/app/components/app.vue
+++ b/src/app/static/src/app/components/app.vue
@@ -9,17 +9,17 @@
                         <div class="dropdown-item" v-for="region in currentProject.regions">
                             <router-link :to="region.url" class="text-success">{{ region.name }}</router-link>
                         </div>
-                        <div class="dropdown-item">
+                        <div v-if="currentProject.regions.length < maxRegions" class="dropdown-item">
                             <a v-b-modal.add-region>+ Add region</a>
                         </div>
                     </drop-down>
                 </li>
                 <li class="full-height">
-                    <a href="#" class="px-2 text-dark project-nav"
+                    <router-link to="/strategise" class="px-2 text-dark project-nav"
                        id="stratAcrossRegions"
-                       v-if="stratAcrossRegionsIsEnabled">Strategize across regions
+                       v-if="stratAcrossRegionsIsEnabled && currentProject.regions.length > 1">Strategize across regions
                         <b-icon-graph-up></b-icon-graph-up>
-                    </a>
+                    </router-link>
                 </li>
             </ul>
             <ul class="navbar-nav ml-auto mr-3">
@@ -67,6 +67,7 @@
     import {RootMutation} from "../mutations";
     import {switches} from "../featureSwitches";
     import userGuideLinks from "./userGuideLinks.vue";
+    import {MAX_REGIONS} from "../index";
 
     interface Methods {
         fetchDocs: () => void
@@ -95,6 +96,7 @@
             return {
                 newRegionName: "",
                 stratAcrossRegionsIsEnabled: switches.stratAcrossRegions,
+                maxRegions: MAX_REGIONS
             }
         },
         components: {dropDown, BIconGraphUp, BModal, userGuideLinks},

--- a/src/app/static/src/app/components/app.vue
+++ b/src/app/static/src/app/components/app.vue
@@ -15,9 +15,9 @@
                     </drop-down>
                 </li>
                 <li class="full-height">
-                    <router-link to="/strategise" class="px-2 text-dark project-nav"
-                       id="stratAcrossRegions"
-                       v-if="stratAcrossRegionsIsEnabled && currentProject.regions.length > 1">Strategize across regions
+                    <router-link to="/strategise" class="px-2 text-dark project-nav" id="stratAcrossRegions"
+                                 v-if="stratAcrossRegionsIsEnabled">
+                        Strategize across regions
                         <b-icon-graph-up></b-icon-graph-up>
                     </router-link>
                 </li>
@@ -73,17 +73,17 @@
         fetchDocs: () => void
         fetchBaselineOptions: () => void
         fetchInterventionOptions: () => void
-        addRegion: (region: Region) => void,
+        addRegion: (region: Region) => void
         createNewRegion: () => void
         cancel: () => void
     }
 
     interface Data {
-        newRegionName: string;
-        stratAcrossRegionsIsEnabled: boolean;
+        newRegionName: string
     }
 
     interface Computed {
+        stratAcrossRegionsIsEnabled: boolean
         currentProject: Project
         baselineOptions: DynamicFormMeta
         interventionOptions: DynamicFormMeta
@@ -95,7 +95,6 @@
         data() {
             return {
                 newRegionName: "",
-                stratAcrossRegionsIsEnabled: switches.stratAcrossRegions,
                 maxRegions: MAX_REGIONS
             }
         },
@@ -112,6 +111,11 @@
                 // also represent a naming clash, so compare slugs rather than names
                 const newRegionSlug = getSlug(this.newRegionName);
                 return !this.currentProject.regions.find(r => r.slug == newRegionSlug);
+            },
+            stratAcrossRegionsIsEnabled() {
+              return switches.stratAcrossRegions &&
+                  // Exclude regions that aren't fully initialised
+                  this.currentProject.regions.filter(region => region.interventionSettings.budgetAllZones).length > 1;
             }
         },
         methods: {

--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -16,6 +16,7 @@ const names: Record<string, string> = {
   "none": "No intervention"
 };
 
+// BTable uses Bootstrap colour variants for styling: https://bootstrap-vue.org/docs/components/table#items-record-data
 const colours: Record<string, string> = {
   "irs": "primary",
   "llin-pbo": "secondary",

--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -8,7 +8,7 @@ import Vue from "vue";
 import {StrategyWithThreshold} from "../../../models/project";
 
 const names: Record<string, string> = {
-  "irs": "IRS only",
+  "irs": "IRS* only",
   "llin-pbo": "Pyrethroid-PBO ITN only",
   "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS*",
   "llin": "Pyrethroid LLIN only",

--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -1,0 +1,70 @@
+<template>
+  <b-table :items="items"></b-table>
+</template>
+
+<script lang="ts">
+import {BTable} from "bootstrap-vue";
+import Vue from "vue";
+import {StrategyWithThreshold} from "../../../models/project";
+
+const names: Record<string, string> = {
+  "irs": "IRS only",
+  "llin-pbo": "Pyrethroid-PBO ITN only",
+  "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS*",
+  "llin": "Pyrethroid LLIN only",
+  "irs-llin": "Pyrethroid LLIN with IRS*",
+  "none": "No intervention"
+};
+
+const colours: Record<string, string> = {
+  "irs": "primary",
+  "llin-pbo": "secondary",
+  "irs-llin-pbo": "danger",
+  "llin": "success",
+  "irs-llin": "warning",
+  "none": ""
+};
+
+const costFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+});
+
+const casesFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+interface Computed {
+  items: Record<string, any>[]
+}
+
+interface Props {
+  strategies: StrategyWithThreshold[]
+}
+
+export default Vue.extend<void, void, Computed, Props>({
+  components: {
+    BTable
+  },
+  props: {
+    strategies: Array
+  },
+  computed: {
+    items() {
+      return this.strategies.map((e: any, i: number) => ({
+        " ": `Strategy ${i + 1}`,
+        "maximum_cost_vs_budget": `${e.costThreshold * 100}%`,
+        ...e.strategy.interventions.reduce((a: any, f: any) => ({...a, [f.zone]: names[f.intervention]}), {}),
+        "total_cases_averted": casesFormatter.format(e.strategy.casesAverted),
+        "total_cost": costFormatter.format(e.strategy.cost),
+        "_cellVariants": e.strategy.interventions.reduce((a: any, f: any) => ({
+          ...a,
+          [f.zone]: colours[f.intervention]
+        }), {})
+      }));
+    }
+  }
+});
+</script>

--- a/src/app/static/src/app/components/strategisePage.vue
+++ b/src/app/static/src/app/components/strategisePage.vue
@@ -10,14 +10,16 @@
         <component style="vertical-align: top" :is="documentationChevronComponent"></component>
       </a>
       <b-collapse :visible="showDocumentation">
-        <div class="my-1" v-html="'<p>This tool can investigate how different interventions could be ' +
+        <div class="my-2" v-html="'<p>This tool can investigate how different interventions could be ' +
         'distributed cross wider regions to minimise the overall number of malaria cases whilst achieving local ' +
         'goals.</p>' +
         '<p>In some circumstances the next best option might be substantially lower cost. To investigate this the ' +
         'tool outputs not only the best option but shows which combination of interventions give slightly reduced ' +
         'budgets. The tool presents 5 potential strategies, allowing the user to determine and explore potential ' +
         'strategies for vector control across regions.</p>' +
-        '<p>Please see the user manual for more information.</p>'"></div>
+        '<p>Please see the user manual for more information.</p>' +
+        '<p><i>*IRS refers to a long-lasting non-pyrethroid IRS product (impact reflects recent Actellic 300CS and ' +
+        'SumiShield products).</i></p>'"></div>
       </b-collapse>
     </div>
     <div class="form mt-5">

--- a/src/app/static/src/app/components/strategisePage.vue
+++ b/src/app/static/src/app/components/strategisePage.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="strategise container mt-5">
+    <h1 class="h3 text-center">
+      Strategize across regions
+    </h1>
+    <div class="help mt-2 text-center">
+      <a href="#" @click="showDocumentation = !showDocumentation">
+        <info-icon></info-icon>
+        How to use this page
+        <component style="vertical-align: top" :is="documentationChevronComponent"></component>
+      </a>
+      <b-collapse :visible="showDocumentation">
+        <div class="my-1" v-html="'<p>This tool can investigate how different interventions could be ' +
+        'distributed cross wider regions to minimise the overall number of malaria cases whilst achieving local ' +
+        'goals.</p>' +
+        '<p>In some circumstances the next best option might be substantially lower cost. To investigate this the ' +
+        'tool outputs not only the best option but shows which combination of interventions give slightly reduced ' +
+        'budgets. The tool presents 5 potential strategies, allowing the user to determine and explore potential ' +
+        'strategies for vector control across regions.</p>' +
+        '<p>Please see the user manual for more information.</p>'"></div>
+      </b-collapse>
+    </div>
+    <div class="form mt-5">
+      <b-form inline class="justify-content-center" @submit.prevent="submit">
+        <label class="mr-sm-2" for="inline-form-input-budget">Total available budget</label>
+        <span class="icon-small mr-sm-3"
+              v-tooltip="'The total available budget to cover the next 3-years is required to assess the most feasible intervention options across regions'">
+          <help-circle-icon></help-circle-icon>
+        </span>
+        <b-input-group prepend="$USD" class="mb-2 mr-sm-3 mb-sm-0">
+          <b-form-input id="inline-form-input-budget" v-model="currentProject.budget" type="number" min="0"
+                        :number="true" :required="true"></b-form-input>
+        </b-input-group>
+        <b-button type="submit" variant="primary">Strategize</b-button>
+      </b-form>
+    </div>
+    <div class="summary mt-5">
+      <loading-spinner v-if="strategising" size="lg" class="mx-auto"></loading-spinner>
+      <strategies-table v-if="strategies.length" :strategies="strategies"></strategies-table>
+      <b-alert :show="errors.length > 0" variant="danger" dismissible @dismissed="dismissErrors">
+        <h5 class="alert-heading">Errors occurred when strategizing</h5>
+        <dl v-for="(error, index) in errors" :key="index">
+          <dt>{{ error.error }}</dt>
+          <dd v-if="error.detail">{{ error.detail }}</dd>
+        </dl>
+      </b-alert>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import {mapActions, mapState} from "vuex";
+import {Project, StrategyWithThreshold} from "../models/project";
+import {RootAction} from "../actions";
+import {VTooltip} from "v-tooltip";
+import {ChevronDownIcon, ChevronUpIcon, HelpCircleIcon, InfoIcon} from "vue-feather-icons";
+import loadingSpinner from "./loadingSpinner.vue";
+import strategiesTable from "./figures/strategise/strategiesTable.vue";
+import {BAlert, BButton, BCollapse, BForm, BFormInput, BInputGroup} from "bootstrap-vue";
+import {APIError} from "../apiService";
+
+interface Data {
+  strategising: boolean
+  showDocumentation: boolean
+}
+
+interface Methods {
+  strategise: () => void
+  submit: () => void
+  dismissErrors: () => void
+}
+
+interface Computed {
+  currentProject: Project
+  errors: APIError[]
+  strategies: StrategyWithThreshold[]
+  documentationChevronComponent: string
+}
+
+export default Vue.extend<Data, Methods, Computed>({
+  components: {
+    strategiesTable,
+    HelpCircleIcon,
+    loadingSpinner,
+    BForm,
+    BFormInput,
+    BInputGroup,
+    BButton,
+    BAlert,
+    BCollapse,
+    InfoIcon,
+    ChevronDownIcon,
+    ChevronUpIcon
+  },
+  directives: {
+    tooltip: VTooltip
+  },
+  data() {
+    return {
+      strategising: false,
+      showDocumentation: false
+    }
+  },
+  computed: {
+    ...mapState(["currentProject", "errors"]),
+    strategies() {
+      return this.currentProject ? this.currentProject.strategies : [];
+    },
+    documentationChevronComponent() {
+      return this.showDocumentation ? "chevron-up-icon" : "chevron-down-icon";
+    }
+  },
+  methods: {
+    ...mapActions({
+      strategise: RootAction.Strategise,
+      dismissErrors: RootAction.DismissErrors
+    }),
+    submit: async function () {
+      this.strategising = true;
+      await this.strategise();
+      this.strategising = false;
+    }
+  }
+});
+</script>

--- a/src/app/static/src/app/components/strategisePage.vue
+++ b/src/app/static/src/app/components/strategisePage.vue
@@ -28,7 +28,7 @@
           <help-circle-icon></help-circle-icon>
         </span>
         <b-input-group prepend="$USD" class="mb-2 mr-sm-3 mb-sm-0">
-          <b-form-input id="inline-form-input-budget" v-model="currentProject.budget" type="number" min="0"
+          <b-form-input id="inline-form-input-budget" :value="budget" @update="update" type="number" min="0"
                         :number="true" :required="true"></b-form-input>
         </b-input-group>
         <b-button type="submit" variant="primary">Strategize</b-button>
@@ -63,10 +63,13 @@ import {APIError} from "../apiService";
 interface Data {
   strategising: boolean
   showDocumentation: boolean
+  budget: number
 }
 
 interface Methods {
+  setBudget: (payload: { budget: number }) => void
   strategise: () => void
+  update: (budget: number) => void
   submit: () => void
   dismissErrors: () => void
 }
@@ -99,7 +102,8 @@ export default Vue.extend<Data, Methods, Computed>({
   data() {
     return {
       strategising: false,
-      showDocumentation: false
+      showDocumentation: false,
+      budget: this.$store.state.currentProject.budget
     }
   },
   computed: {
@@ -113,9 +117,13 @@ export default Vue.extend<Data, Methods, Computed>({
   },
   methods: {
     ...mapActions({
+      setBudget: RootAction.SetBudget,
       strategise: RootAction.Strategise,
       dismissErrors: RootAction.DismissErrors
     }),
+    update: function (budget: number) {
+      this.setBudget({ budget });
+    },
     submit: async function () {
       this.strategising = true;
       await this.strategise();

--- a/src/app/static/src/app/index.ts
+++ b/src/app/static/src/app/index.ts
@@ -3,6 +3,8 @@ import app from "./components/app.vue";
 import {store} from "./store";
 import {router} from "./router";
 
+export const MAX_REGIONS = 15;
+
 export const mint = new Vue({
     el: "#app",
     render: h => h(app),

--- a/src/app/static/src/app/localStorageManager.ts
+++ b/src/app/static/src/app/localStorageManager.ts
@@ -14,7 +14,8 @@ const stripDataFromProject = (project: Project): Project => {
     return {
         ...project,
         currentRegion: stripDataFromRegion(project.currentRegion),
-        regions: project.regions.map(stripDataFromRegion)
+        regions: project.regions.map(stripDataFromRegion),
+        strategies: []
     }
 }
 

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -48,18 +48,29 @@ export interface Project {
     slug: string;
     regions: Region[];
     currentRegion: Region;
+    strategies: StrategyWithThreshold[];
+    budget: number;
 }
 
 export class Project {
-
     constructor(name: string,
                 regionsName: string[],
                 baselineOptions: DynamicFormMeta,
                 interventionOptions: DynamicFormMeta,
-                currentRegion: Region | null = null) {
+                currentRegion: Region | null = null,
+                strategies: StrategyWithThreshold[] = [],
+                budget: number = 2_000_000
+    ) {
         this.name = name;
         this.slug = getSlug(name);
         this.regions = regionsName.map(n => new Region(n, this, baselineOptions, interventionOptions));
-        this.currentRegion = currentRegion || this.regions[0]
+        this.currentRegion = currentRegion || this.regions[0];
+        this.strategies = strategies;
+        this.budget = budget;
     }
+}
+
+export interface StrategyWithThreshold {
+    costThreshold: number
+    strategy: object
 }

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -30,6 +30,7 @@ export enum RootMutation {
     DeleteProject = "DeleteProject",
     UpdateImpactDocs = "UpdateImpactDocs",
     UpdateCostDocs = "UpdateCostDocs",
+    SetBudget = "SetBudget",
     UpdateStrategies = "UpdateStrategies"
 }
 
@@ -154,6 +155,10 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.UpdateCostDocs](state: RootState, payload: string) {
         state.costDocs = payload;
+    },
+
+    [RootMutation.SetBudget](state: RootState, payload: number) {
+        state.currentProject!!.budget = payload;
     },
 
     [RootMutation.UpdateStrategies](state: RootState, payload: StrategyWithThreshold[]) {

--- a/src/app/static/src/app/mutations.ts
+++ b/src/app/static/src/app/mutations.ts
@@ -1,6 +1,6 @@
 import {MutationTree} from "vuex";
 import {RootState} from "./store";
-import {Project, Region} from "./models/project";
+import {Project, Region, StrategyWithThreshold} from "./models/project";
 import {APIError} from "./apiService";
 import {Data, Graph, TableDefinition} from "./generated";
 import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
@@ -16,6 +16,7 @@ export enum RootMutation {
     SetCurrentRegionInterventionSettings = "SetCurrentRegionInterventionSettings",
     SetCurrentRegionStep = "SetCurrentRegionStep",
     AddError = "AddError",
+    DismissErrors = "DismissErrors",
     AddBaselineOptions = "AddBaselineOptions",
     AddInterventionOptions = "AddInterventionOptions",
     AddPrevalenceGraphData = "AddPrevalenceGraphData",
@@ -28,7 +29,8 @@ export enum RootMutation {
     AddCostPerCaseGraphConfig = "AddCostPerCaseGraphConfig",
     DeleteProject = "DeleteProject",
     UpdateImpactDocs = "UpdateImpactDocs",
-    UpdateCostDocs = "UpdateCostDocs"
+    UpdateCostDocs = "UpdateCostDocs",
+    UpdateStrategies = "UpdateStrategies"
 }
 
 export const mutations: MutationTree<RootState> = {
@@ -81,7 +83,10 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.SetCurrentRegionInterventionSettings](state: RootState, payload: DynamicFormData) {
         if (state.currentProject) {
-            state.currentProject.currentRegion.interventionSettings = payload;
+            state.currentProject.currentRegion.interventionSettings = {
+                budgetAllZones: state.currentProject.budget,
+                ...payload
+            };
         }
     },
 
@@ -93,6 +98,10 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.AddError](state: RootState, payload: APIError) {
         state.errors.push(payload)
+    },
+
+    [RootMutation.DismissErrors](state: RootState) {
+        state.errors = [];
     },
 
     [RootMutation.AddBaselineOptions](state: RootState, payload: DynamicFormMeta) {
@@ -145,6 +154,12 @@ export const mutations: MutationTree<RootState> = {
 
     [RootMutation.UpdateCostDocs](state: RootState, payload: string) {
         state.costDocs = payload;
+    },
+
+    [RootMutation.UpdateStrategies](state: RootState, payload: StrategyWithThreshold[]) {
+        if (state.currentProject) {
+            state.currentProject.strategies = payload;
+        }
     }
 
 };

--- a/src/app/static/src/app/router.ts
+++ b/src/app/static/src/app/router.ts
@@ -4,12 +4,15 @@ import projectListPage from "./components/projectListPage.vue";
 import accessibilityPage from "./components/accessibilityPage.vue"
 // @ts-ignore Dynamic imports not supported error
 const regionPage = () => import("./components/regionPage.vue");
+// @ts-ignore Dynamic imports not supported error
+const strategisePage = () => import("./components/strategisePage.vue");
 
 
 const routes = [
     {path: "/", component: projectListPage},
     {path: "/projects/:project/regions/:region", component: regionPage},
-    {path: "/accessibility", component: accessibilityPage}
+    {path: "/accessibility", component: accessibilityPage},
+    {path: "/strategise", component: strategisePage}
 ];
 
 export const router = new VueRouter({

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -1,0 +1,33 @@
+.strategise {
+  .summary {
+    tr td:first-child {
+      font-weight: 700;
+      white-space: nowrap;
+    }
+    .table-success {
+      background-color: #bbf0fb;
+    }
+    .table-secondary {
+      background-color: #e0fae0;
+    }
+    .table-primary {
+      background-color: #dbb8db;
+    }
+    .table-warning {
+      background-color: #f5c6cb;
+    }
+    .table-danger {
+      background-color: #ffe6b8;
+    }
+    .lds-spin {
+      display: block;
+    }
+  }
+  .form {
+    .icon-small svg {
+      height: 20px;
+      width: 20px;
+      vertical-align: sub;
+    }
+  }
+}

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -5,6 +5,7 @@
 @import "partials/baseline.scss";
 @import "partials/interventions.scss";
 @import "partials/graph.scss";
+@import "partials/strategise.scss";
 @import '../../node_modules/bootstrap-vue/dist/bootstrap-vue.css';
 
 html {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -9,8 +9,13 @@ import {BModal} from "bootstrap-vue";
 import {RootMutation} from "../../app/mutations";
 import VueRouter from "vue-router";
 import {switches} from "../../app/featureSwitches";
+import {MAX_REGIONS} from "../../app";
 
 describe("app", () => {
+    const oldStratAcrossRegions = switches.stratAcrossRegions;
+    afterEach(() => {
+        switches.stratAcrossRegions = oldStratAcrossRegions;
+    });
 
     const localVue = createLocalVue();
     localVue.use(VueRouter);
@@ -46,6 +51,7 @@ describe("app", () => {
     });
 
     it("show project menu if currentProject is not null", () => {
+        switches.stratAcrossRegions = false;
         const state = {
             currentProject: new Project(
                 "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
@@ -60,11 +66,41 @@ describe("app", () => {
         expect(firstNavLink.html())
             .toBe("<router-link-stub to=\"/projects/my-project/regions/region1\"" +
                 " tag=\"a\" event=\"click\" class=\"text-success\">region1</router-link-stub>");
-        if (switches.stratAcrossRegions) {
-            expect(wrapper.findAll("#stratAcrossRegions").length).toBe(1);
-            expect(wrapper.find("#stratAcrossRegions").text()).toBe("Strategize across regions");
-            expect(wrapper.find("#stratAcrossRegions").attributes("href")).toBe("#");
-        } else expect(wrapper.findAll("#stratAcrossRegions").length).toBe(0);
+        expect(wrapper.findAll("#stratAcrossRegions").length).toBe(0);
+    });
+
+    it("hides add region link if maximum region count has been reached", () => {
+        const state = {
+            currentProject: new Project(
+                "my project", Array(MAX_REGIONS).fill(""), {controlSections: []}, {controlSections: []}
+            )
+        };
+        const wrapper = getWrapper(state);
+        expect(wrapper.findAll(".dropdown-item").length).toBe(MAX_REGIONS);
+    });
+
+    it("shows strategise link if feature enabled", () => {
+        switches.stratAcrossRegions = true;
+        const state = {
+            currentProject: new Project(
+                "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
+            )
+        };
+        const wrapper = getWrapper(state);
+        expect(wrapper.findAll("#stratAcrossRegions").length).toBe(1);
+        expect(wrapper.find("#stratAcrossRegions").text()).toBe("Strategize across regions");
+        expect(wrapper.find("#stratAcrossRegions").attributes("to")).toBe("/strategise");
+    });
+
+    it("does not show strategise link if fewer than two regions exist", () => {
+        switches.stratAcrossRegions = true;
+        const state = {
+            currentProject: new Project(
+                "my project", ["region1"], {controlSections: []}, {controlSections: []}
+            )
+        };
+        const wrapper = getWrapper(state);
+        expect(wrapper.findAll("#stratAcrossRegions").length).toBe(0);
     });
 
     it("fetches docs and options before mount", () => {

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -81,24 +81,26 @@ describe("app", () => {
 
     it("shows strategise link if feature enabled", () => {
         switches.stratAcrossRegions = true;
-        const state = {
-            currentProject: new Project(
-                "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
-            )
-        };
+        const project = new Project(
+            "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
+        );
+        project.regions.forEach(region => {
+            region.interventionSettings.budgetAllZones = 42;
+        });
+        const state = { currentProject: project };
         const wrapper = getWrapper(state);
         expect(wrapper.findAll("#stratAcrossRegions").length).toBe(1);
         expect(wrapper.find("#stratAcrossRegions").text()).toBe("Strategize across regions");
         expect(wrapper.find("#stratAcrossRegions").attributes("to")).toBe("/strategise");
     });
 
-    it("does not show strategise link if fewer than two regions exist", () => {
+    it("does not show strategise link if fewer than two fully initialised regions exist", () => {
         switches.stratAcrossRegions = true;
-        const state = {
-            currentProject: new Project(
-                "my project", ["region1"], {controlSections: []}, {controlSections: []}
-            )
-        };
+        const project = new Project(
+            "my project", ["region1", "region2"], {controlSections: []}, {controlSections: []}
+        );
+        project.regions[0].interventionSettings.budgetAllZones = 42;
+        const state = { currentProject: project };
         const wrapper = getWrapper(state);
         expect(wrapper.findAll("#stratAcrossRegions").length).toBe(0);
     });

--- a/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
@@ -1,0 +1,50 @@
+import {mount} from "@vue/test-utils";
+import StrategiesTable from "../../../../app/components/figures/strategise/strategiesTable.vue";
+import {BTable} from "bootstrap-vue";
+
+describe("strategies table", () => {
+
+    it("renders table", () => {
+        const wrapper = mount(StrategiesTable, {
+            propsData: {
+                strategies: [
+                    {
+                        costThreshold: 1,
+                        strategy: {
+                            casesAverted: 100,
+                            cost: 1000,
+                            interventions: [
+                                {zone: "Region A", intervention: "irs-llin-pbo"},
+                                {zone: "Region B", intervention: "irs-llin"}
+                            ]
+                        }
+                    },
+                    {
+                        costThreshold: 0.95,
+                        strategy: {
+                            casesAverted: 50,
+                            cost: 500,
+                            interventions: [
+                                {zone: "Region A", intervention: "pbo-llin"},
+                                {zone: "Region B", intervention: "llin"}
+                            ]
+                        }
+                    }
+                ]
+            }
+        });
+        expect(wrapper.find(BTable).exists()).toBe(true);
+        expect(wrapper.findAll("tbody tr").length).toBe(2);
+        expect(wrapper.findAll("th").length).toBe(6);
+        const row1 = wrapper.findAll("tbody tr:first-child td");
+        expect(row1.at(0).text()).toBe("Strategy 1");
+        expect(row1.at(1).text()).toBe("100%");
+        expect(row1.at(2).text()).toBe("Pyrethroid-PBO ITN with IRS*");
+        expect(row1.at(2).classes()).toContain("table-danger");
+        expect(row1.at(3).text()).toBe("Pyrethroid LLIN with IRS*");
+        expect(row1.at(3).classes()).toContain("table-warning");
+        expect(row1.at(4).text()).toBe("100");
+        expect(row1.at(5).text()).toBe("$1,000");
+    });
+
+});

--- a/src/app/static/src/tests/components/projectPageList.test.ts
+++ b/src/app/static/src/tests/components/projectPageList.test.ts
@@ -128,7 +128,9 @@ describe("project page", () => {
                 prevalenceGraphData: [],
                 tableData: [],
                 step: 1
-            }
+            },
+            strategies: [],
+            budget: 2_000_000
         });
 
         // options should equal options from store, but be fresh deep copy
@@ -182,7 +184,9 @@ describe("project page", () => {
                 prevalenceGraphData: [],
                 tableData: [],
                 step: 1
-            }
+            },
+            strategies: [],
+            budget: 2_000_000
         });
 
         expect(mockRouter[0].path).toBe("/projects/new-project/regions/south");

--- a/src/app/static/src/tests/components/strategisePage.test.ts
+++ b/src/app/static/src/tests/components/strategisePage.test.ts
@@ -1,0 +1,96 @@
+import {mount} from "@vue/test-utils";
+import StrategisePage from "../../app/components/strategisePage.vue";
+import Vuex from "vuex";
+import {RootAction} from "../../app/actions";
+import loadingSpinner from "../../app/components/loadingSpinner.vue";
+import {BAlert} from "bootstrap-vue";
+import {mockError, mockProject, mockRootState} from "../mocks";
+import {APIError} from "../../app/apiService";
+import strategiesTable from "../../app/components/figures/strategise/strategiesTable.vue";
+import Vue from "vue";
+
+describe("strategise page", () => {
+
+    const createStore = (mockStrategiseAction = jest.fn(), errors: APIError[] = []) => {
+        return new Vuex.Store({
+            state: mockRootState({
+                currentProject: mockProject(),
+                errors
+            }),
+            actions: {
+                [RootAction.Strategise]: mockStrategiseAction
+            }
+        });
+    };
+
+    it("populates budget input from project settings", () => {
+        const store = createStore();
+        const wrapper = mount(StrategisePage, {store});
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.value).toBe("10000");
+    });
+
+    it("propagates budget change to project settings", () => {
+        const store = createStore();
+        const wrapper = mount(StrategisePage, {store});
+        expect(store.state.currentProject!.budget).toBe(10000);
+        wrapper.find("input").setValue("20000");
+        expect(store.state.currentProject!.budget).toBe(20000);
+    });
+
+    it("triggers action and sets strategising flag when form submitted", () => {
+        const mockStrategiseAction = jest.fn();
+        const store = createStore(mockStrategiseAction);
+        const wrapper = mount(StrategisePage, {store});
+        wrapper.find("form").trigger("submit");
+        expect(wrapper.vm.$data.strategising).toBe(true);
+        expect(mockStrategiseAction.mock.calls.length).toBe(1);
+    });
+
+    it("displays spinner while strategising", async () => {
+        const store = createStore();
+        const wrapper = mount(StrategisePage, {
+            store,
+            data() {
+                return {
+                    strategising: true
+                };
+            }
+        });
+        expect(wrapper.find(loadingSpinner).exists()).toBe(true);
+        await wrapper.setData({strategising: false});
+        expect(wrapper.find(loadingSpinner).exists()).toBe(false);
+    });
+
+    it("displays table", async () => {
+        const store = createStore();
+        const wrapper = mount(StrategisePage, {store});
+        expect(wrapper.find(strategiesTable).exists()).toBe(false);
+        store.state.currentProject!.strategies = [
+            {
+                costThreshold: 1,
+                strategy: {
+                    casesAverted: 100,
+                    cost: 1000,
+                    interventions: [
+                        {zone: "Region A", intervention: "irs-llin-pbo"},
+                        {zone: "Region B", intervention: "irs-llin"}
+                    ]
+                }
+            }
+        ];
+        await Vue.nextTick();
+        expect(wrapper.find(strategiesTable).exists()).toBe(true);
+    });
+
+    it("displays errors", () => {
+        const store = createStore(jest.fn(), [mockError("DETAIL")]);
+        const wrapper = mount(StrategisePage, {store});
+        const alert = wrapper.find(BAlert);
+        expect(alert.exists()).toBe(true);
+        expect(alert.findAll("dl").length).toBe(1);
+        expect(alert.find("dl dt").text()).toBe("OTHER_ERROR");
+        expect(alert.find("dl dd").text()).toBe("DETAIL");
+    });
+
+});

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -4,9 +4,9 @@ import {DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("actions", () => {
 
-    const getStateWithBaselineSettings = async () => {
+    const getSettingsFromOptions = async (action: RootAction) => {
         const commit = jest.fn();
-        await (actions[RootAction.FetchBaselineOptions] as any)({commit} as any);
+        await (actions[action] as any)({commit} as any);
         const options = commit.mock.calls[0][1] as DynamicFormMeta;
         const settings = {} as any;
         options.controlSections.forEach((section) => {
@@ -16,13 +16,29 @@ describe("actions", () => {
                 });
             });
         });
+        return settings;
+    };
+
+    const getStateWithBaselineSettings = async () => {
+        const settings = await getSettingsFromOptions(RootAction.FetchBaselineOptions);
         return {
             currentProject: {
                 currentRegion: {
+                    name: "Region A",
                     baselineSettings: settings
-                }
+                },
+                budget: 10_000
             }
         };
+    };
+
+    const getStateWithBaselineAndInterventionSettings = async () => {
+        const state = await getStateWithBaselineSettings();
+        const settings = await getSettingsFromOptions(RootAction.FetchInterventionOptions);
+        Object.assign(state.currentProject.currentRegion, {
+            interventionSettings: settings
+        });
+        return state;
     };
 
     it("can get prevalence graph data", async () => {
@@ -162,7 +178,20 @@ describe("actions", () => {
         expect(new Set(commit.mock.calls.map(call => call[0]))).toEqual(new Set([RootMutation.UpdateImpactDocs, RootMutation.UpdateCostDocs]));
         expect(commit.mock.calls[0][1]).toContain("<ul>");
         expect(commit.mock.calls[1][1]).toContain("<ul>");
+    });
 
+    it("can get strategies", async () => {
+        const commit = jest.fn();
+        const state = await getStateWithBaselineAndInterventionSettings();
+
+        (state.currentProject as any).regions = [state.currentProject.currentRegion];
+
+        await (actions[RootAction.Strategise] as any)({commit, state} as any);
+
+        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls[1][0]).toBe(RootMutation.UpdateStrategies);
+        expect(commit.mock.calls[1][1].length).toBe(5);
+        expect(Object.keys(commit.mock.calls[1][1][0]).sort()).toEqual(["costThreshold", "strategy"]);
     });
 
 });

--- a/src/app/static/src/tests/integration/actions.itest.ts
+++ b/src/app/static/src/tests/integration/actions.itest.ts
@@ -36,7 +36,10 @@ describe("actions", () => {
         const state = await getStateWithBaselineSettings();
         const settings = await getSettingsFromOptions(RootAction.FetchInterventionOptions);
         Object.assign(state.currentProject.currentRegion, {
-            interventionSettings: settings
+            interventionSettings: {
+                ...settings,
+                budgetAllZones: 10_000
+            }
         });
         return state;
     };

--- a/src/app/static/src/tests/localStorageManage.test.ts
+++ b/src/app/static/src/tests/localStorageManage.test.ts
@@ -1,6 +1,6 @@
 import {mockProject, mockRootState} from "./mocks";
 import {localStorageManager, serialiseState} from "../app/localStorageManager";
-import {Project} from "../app/models/project";
+import {Project, StrategyWithThreshold} from "../app/models/project";
 
 describe("local storage manager", () => {
 
@@ -8,8 +8,8 @@ describe("local storage manager", () => {
        localStorage.clear();
     });
 
-    const mockProjectWithData = (name: string, regions: string[]): Project => {
-        const project = mockProject(name, regions)
+    const mockProjectWithData = (name: string, regions: string[], strategies: StrategyWithThreshold[] = []): Project => {
+        const project = mockProject(name, regions, strategies)
         const region = project.regions[0]
 
         // settings should all be preserved
@@ -28,7 +28,7 @@ describe("local storage manager", () => {
 
     it("can strip data from projects", () => {
 
-        const project1 = mockProjectWithData("p1", ["r1"])
+        const project1 = mockProjectWithData("p1", ["r1"], [{costThreshold: 1, strategy: {}}])
         const project2 = mockProjectWithData("p2", ["r2"])
 
         const state = mockRootState({
@@ -70,6 +70,7 @@ describe("local storage manager", () => {
         expect(result.currentProject!!.slug).toBe("p1");
         expect(result.currentProject!!.regions[0]).toEqual(expectedFirstRegion);
         expect(result.currentProject!!.currentRegion).toEqual(expectedFirstRegion);
+        expect(result.currentProject!!.strategies).toEqual([]);
 
         expect(Object.keys(result)).toEqual([
             "projects",

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -3,7 +3,7 @@ import MockAdapter from "axios-mock-adapter";
 import {RootState} from "../app/store";
 import {Graph, ResponseFailure, ResponseSuccess} from "../app/generated";
 import {APIError} from "../app/apiService";
-import {Project, Region} from "../app/models/project";
+import {Project, Region, StrategyWithThreshold} from "../app/models/project";
 
 export function mockRootState(state: Partial<RootState> = {}): RootState {
     return {
@@ -40,8 +40,8 @@ export function mockGraph(props: Partial<Graph> = {}): Graph {
     }
 }
 
-export function mockProject(name = "project 1", regions = ["region 1"]): Project {
-    return new Project(name, regions, {controlSections: []}, {controlSections: []});
+export function mockProject(name = "project 1", regions = ["region 1"], strategies: StrategyWithThreshold[] = [], budget = 10_000): Project {
+    return new Project(name, regions, {controlSections: []}, {controlSections: []}, null, strategies, budget);
 }
 
 export function mockRegion(name: string = "region 1"): Region {

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -349,6 +349,15 @@ describe("actions", () => {
         expect(dispatch.mock.calls[1][0]).toBe(RootAction.FetchTableData);
     });
 
+    it("sets budget", () => {
+        const commit = jest.fn();
+        (actions[RootAction.SetBudget] as any)({commit} as any, {budget: 42});
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe(RootMutation.SetBudget);
+        expect(commit.mock.calls[0][1]).toBe(42);
+
+    });
+
     it("fetches strategies", async () => {
         const url = "/strategise";
         const options = {budget: 10_000, zones: [{baselineSettings, interventionSettings}]};

--- a/src/app/static/src/tests/store/actions.test.ts
+++ b/src/app/static/src/tests/store/actions.test.ts
@@ -360,16 +360,32 @@ describe("actions", () => {
 
     it("fetches strategies", async () => {
         const url = "/strategise";
-        const options = {budget: 10_000, zones: [{baselineSettings, interventionSettings}]};
         const strategies = [{costThreshold: 1}];
-        mockAxios.onPost(url, options)
+        mockAxios.onPost(url)
             .reply(200, mockSuccess(strategies));
         const commit = jest.fn();
+        const mockRegion = {interventionSettings: {budgetAllZones: 42}};
+        const mockState = {
+            currentProject: {
+                currentRegion: mockRegion,
+                regions: [
+                    mockRegion,
+                    mockRegion
+                ],
+                budget: 10_000
+            }
+        };
 
-        await (actions[RootAction.Strategise] as any)({commit, state} as any);
+        await (actions[RootAction.Strategise] as any)({commit, state: mockState} as any);
 
         expect(mockAxios.history.post[0].url).toBe(url);
-        expect(mockAxios.history.post[0].data).toBe(JSON.stringify(options));
+        expect(mockAxios.history.post[0].data).toBe(JSON.stringify({
+            budget: 10000,
+            zones: [
+                {interventionSettings: {budgetAllZones: 42}},
+                {interventionSettings: {budgetAllZones: 42}},
+            ]
+        }));
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toBe(RootMutation.UpdateStrategies);
         expect(commit.mock.calls[0][1]).toEqual([]);

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -286,6 +286,15 @@ describe("mutations", () => {
         expect(state.costDocs).toBe("cost docs");
     });
 
+    it("sets budget", () => {
+        const state = mockRootState({
+            currentProject: mockProject()
+        });
+        mutations[RootMutation.SetBudget](state, 42);
+
+        expect(state.currentProject!!.budget).toBe(42);
+    });
+
     it("updates strategies", () => {
         const project = mockProject();
         const state = mockRootState({

--- a/src/app/static/src/tests/store/mutations.test.ts
+++ b/src/app/static/src/tests/store/mutations.test.ts
@@ -2,7 +2,7 @@ import {mutations, RootMutation} from "../../app/mutations";
 import {mockError, mockProject, mockRegion, mockRootState} from "../mocks";
 import {Project} from "../../app/models/project";
 import {expectAllDefined} from "../testHelpers";
-import {DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
+import {DynamicControlType, DynamicFormData, DynamicFormMeta} from "@reside-ic/vue-dynamic-form";
 
 describe("mutations", () => {
 
@@ -245,7 +245,7 @@ describe("mutations", () => {
         const newSettings: DynamicFormData = {"c1": 3};
         mutations[RootMutation.SetCurrentRegionInterventionSettings](state, newSettings);
         expect(state.currentProject!!.currentRegion.interventionSettings)
-            .toEqual(newSettings);
+            .toEqual({budgetAllZones:2000000, ...newSettings});
     });
 
     it("updating the current region's intervention settings does nothing if not current project", () => {
@@ -284,5 +284,24 @@ describe("mutations", () => {
         const state = mockRootState();
         mutations[RootMutation.UpdateCostDocs](state, "cost docs");
         expect(state.costDocs).toBe("cost docs");
+    });
+
+    it("updates strategies", () => {
+        const project = mockProject();
+        const state = mockRootState({
+            currentProject: project
+        });
+        mutations[RootMutation.UpdateStrategies](state, ["some strategies"]);
+
+        expect(state.currentProject!!.strategies).toStrictEqual(["some strategies"]);
+    });
+
+    it("dismisses errors", () => {
+        const state = mockRootState({
+            errors: [mockError("TEST ERROR")]
+        });
+       mutations[RootMutation.DismissErrors](state);
+
+       expect(state.errors).toStrictEqual([]);
     });
 });

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-2491

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-2491
+master

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Changes:
- Add strategise page: budget input form and summary table ([mockups](https://imperiallondon.sharepoint.com/:w:/r/sites/MRCGIDA-mint-dev/Shared%20Documents/mint-dev/Optimisation/Stategize%20across%20regions%20-%20mockups.docx?d=w989d5cc08537432287ec7ebe14a912b2&csf=1&web=1)). Details charts/table to follow in mrc-2493 and mrc-2494.
- Apply limit of 15 regions to place an upper bound on time taken in optimiser
- Add mutation/action to clear API errors - previously these just accumulated
- Remove vestigial(?) `package-lock.json`

To test:
- Visit localhost:8080/?stratAcrossRegions=true
- Add at least two regions, each of which has at least one intervention configured i.e. >0% ITN and/or IRS (the optimiser will work with no interventions but will return very uninteresting results)
- Click on "Strategize across regions" in the toolbar

Notes:
- There is definitely scope to turn the strategies table into a more metadata-driven component. In particular the display options  parallel some of the dynamic chart configuration we use in the rest of the app. This wouldn't be trivial though, especially dealing with a dynamic number of columns. At the same time it might make sense to also turn use vue-dynamic-form - especially if we were to add an inline (i.e. horizontal layout). Keen to hear thoughts on this - would have been hard to do speculatively but may merit a follow-up ticket.
- There is now something of a disconnect between the per-region part of the app and the new page which operates across regions. In particular the global budget needs to be accessible to each region because it is used in a formula in the graph metadata. This necessitates copying the budget into each region's settings when it changes. This also means that there is part of the settings that isn't derived directly from the dynamic forms used to otherwise configure each region. I can't see a way to resolve this without a more significant restructure of the app. If the dynamic form allowed hidden fields then we could somehow link one with a reference to a setting elsewhere in the store/state, but that's not ideal.
- There are a couple of usability issues remaining (now noted on top-level ticket mrc-2434):
  - There has never been a project page, only regions. So to strategise for a project you first have to select a region, which enables the strategise tab if the implicitly-selected project has more than one region
  - If you do create many regions (e.g. >5) then the strategies table can get very crowded
- Feature flag will be removed in mrc-2505
- This branch depends on mrc-ide/mintr#59

To-do:
- [x] Revert to mintr master