### PR TITLE
mrc-2494 Implement strategy table for strategising across regions

### DIFF
--- a/buildkite/test-e2e.dockerfile
+++ b/buildkite/test-e2e.dockerfile
@@ -3,5 +3,5 @@ FROM mrcide/mint-shared-build-env:$GIT_ID
 
 RUN cd app/static && npx playwright install chromium
 
-CMD ./gradlew app:bootRun & sleep 60 && \
+CMD ./gradlew app:bootRun & sleep 90 && \
     npm run e2e-test --prefix=app/static

--- a/src/app/static/src/app/components/figures/strategise/strategyTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategyTable.vue
@@ -1,0 +1,69 @@
+<template>
+  <b-table :items="items"></b-table>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import {Region, StrategyWithThreshold} from "../../../models/project";
+import {BTable} from "bootstrap-vue";
+import {formatCases, formatCost, formatPercentage, getInterventionColour, getInterventionName,} from "./util";
+
+interface Computed {
+  populations: Record<string, number>
+  items: Record<string, string | object>[]
+}
+
+interface Props {
+  strategy: StrategyWithThreshold
+}
+
+export default Vue.extend<unknown, unknown, Computed, Props>({
+  components: {
+    BTable
+  },
+  props: {
+    strategy: Object
+  },
+  computed: {
+    populations() {
+      return this.$store.state.currentProject!.regions.reduce((a: Record<string, number>, region: Region) => ({[region.name]: region.baselineSettings["population"] as number, ...a}), {});
+    },
+    items() {
+      const totalCasesAverted = this.strategy.interventions.reduce((a, intervention) => a + intervention.casesAverted, 0);
+      const totalCost = this.strategy.interventions.reduce((a, intervention) => a + intervention.cost, 0);
+      return this.strategy.interventions.map(intervention => {
+        const population = this.populations[intervention.zone];
+        return {
+          region: intervention.zone,
+          intervention: getInterventionName(intervention.intervention),
+          population: String(population),
+          total_cases_averted: formatCases(intervention.casesAverted),
+          percentage_of_total_cases_averted: formatPercentage(intervention.casesAverted / totalCasesAverted),
+          total_costs: formatCost(intervention.cost),
+          percentage_of_total_costs: formatPercentage(intervention.cost / totalCost),
+          cost_per_case_averted: formatCost(intervention.cost / intervention.casesAverted),
+          cost_per_person: formatCost(intervention.cost / population, 2),
+          cases_averted_per_person: formatCases(intervention.casesAverted / population, 1),
+          _cellVariants: {
+            intervention: getInterventionColour(intervention.intervention)
+          }
+        };
+      }).concat({
+        region: "Total",
+        intervention: "",
+        population: String(Object.values(this.populations).reduce((a, population) => a + population, 0)),
+        total_cases_averted: formatCases(totalCasesAverted),
+        percentage_of_total_cases_averted: "100%",
+        total_costs: formatCost(totalCost),
+        percentage_of_total_costs: "100%",
+        cost_per_case_averted: "",
+        cost_per_person: "",
+        cases_averted_per_person: "",
+        _cellVariants: {
+          intervention: ""
+        }
+      });
+    }
+  }
+});
+</script>

--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -1,0 +1,36 @@
+export const formatCost = (cost: number, maximumFractionDigits = 0) => isNaN(cost) ? "NA" : new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits
+}).format(cost);
+
+export const formatCases = (cases: number, maximumFractionDigits = 0) => new Intl.NumberFormat('en-US', {
+    maximumFractionDigits
+}).format(cases);
+
+export const formatPercentage = (percentage: number) => new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumFractionDigits: 1
+}).format(percentage);
+
+const interventionNames: Record<string, string> = {
+    "irs": "IRS* only",
+    "llin-pbo": "Pyrethroid-PBO ITN only",
+    "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS*",
+    "llin": "Pyrethroid LLIN only",
+    "irs-llin": "Pyrethroid LLIN with IRS*",
+    "none": "No intervention"
+};
+export const getInterventionName = (intervention: string) => interventionNames[intervention];
+
+// BTable uses Bootstrap colour variants for styling: https://bootstrap-vue.org/docs/components/table#items-record-data
+const interventionColours: Record<string, string> = {
+    "irs": "primary",
+    "llin-pbo": "secondary",
+    "irs-llin-pbo": "danger",
+    "llin": "success",
+    "irs-llin": "warning",
+    "none": ""
+};
+export const getInterventionColour = (intervention: string) => interventionColours[intervention];

--- a/src/app/static/src/app/models/project.ts
+++ b/src/app/static/src/app/models/project.ts
@@ -28,7 +28,7 @@ export class Region {
         this.baselineOptions = deepCopy(baselineOptions);
         this.baselineSettings = {};
         this.interventionOptions = deepCopy(interventionOptions);
-        this.interventionSettings =  {};
+        this.interventionSettings = {};
         this.interventionOptions.controlSections.map(s => {
             s.controlGroups.map(g => {
                 g.controls.map(c => {
@@ -72,5 +72,10 @@ export class Project {
 
 export interface StrategyWithThreshold {
     costThreshold: number
-    interventions: object[]
+    interventions: {
+        zone: string,
+        intervention: string,
+        cost: number,
+        casesAverted: number
+    }[]
 }

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -1,33 +1,52 @@
 .strategise {
-  .summary {
-    tr td:first-child {
-      font-weight: 700;
-      white-space: nowrap;
-    }
-    .table-success {
-      background-color: #bbf0fb;
-    }
-    .table-secondary {
-      background-color: #e0fae0;
-    }
-    .table-primary {
-      background-color: #dbb8db;
-    }
-    .table-warning {
-      background-color: #f5c6cb;
-    }
-    .table-danger {
-      background-color: #ffe6b8;
-    }
-    .lds-spin {
-      display: block;
-    }
-  }
   .form {
     .icon-small svg {
       height: 20px;
       width: 20px;
       vertical-align: sub;
+    }
+  }
+
+  .results {
+    .lds-spin {
+      display: block;
+    }
+
+    .table-success {
+      background-color: #bbf0fb;
+    }
+
+    .table-secondary {
+      background-color: #e0fae0;
+    }
+
+    .table-primary {
+      background-color: #dbb8db;
+    }
+
+    .table-warning {
+      background-color: #f5c6cb;
+    }
+
+    .table-danger {
+      background-color: #ffe6b8;
+    }
+
+    .summaryTable {
+      tr td:first-child {
+        font-weight: 700;
+        white-space: nowrap;
+      }
+    }
+
+    .detailsTable {
+      tr td:nth-child(2) {
+        white-space: nowrap;
+      }
+
+      tr:last-child {
+        font-weight: bold;
+      }
     }
   }
 }

--- a/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
@@ -1,30 +1,28 @@
-import {mount} from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import StrategiesTable from "../../../../app/components/figures/strategise/strategiesTable.vue";
 import {BTable} from "bootstrap-vue";
 
 describe("strategies table", () => {
 
+    const strategies = [
+        {
+            costThreshold: 1,
+            interventions: [
+                {zone: "Region A", intervention: "irs-llin-pbo", casesAverted: 60, cost: 600},
+                {zone: "Region B", intervention: "irs-llin", casesAverted: 40, cost: 400}
+            ]
+        },
+        {
+            costThreshold: 0.95,
+            interventions: [
+                {zone: "Region A", intervention: "pbo-llin", casesAverted: 35, cost: 300},
+                {zone: "Region B", intervention: "llin", casesAverted: 15, cost: 200}
+            ]
+        }
+    ];
+
     it("renders table", () => {
-        const wrapper = mount(StrategiesTable, {
-            propsData: {
-                strategies: [
-                    {
-                        costThreshold: 1,
-                        interventions: [
-                            {zone: "Region A", intervention: "irs-llin-pbo", casesAverted: 60, cost: 600},
-                            {zone: "Region B", intervention: "irs-llin", casesAverted: 40, cost: 400}
-                        ]
-                    },
-                    {
-                        costThreshold: 0.95,
-                        interventions: [
-                            {zone: "Region A", intervention: "pbo-llin", casesAverted: 35, cost: 300},
-                            {zone: "Region B", intervention: "llin", casesAverted: 15, cost: 200}
-                        ]
-                    }
-                ]
-            }
-        });
+        const wrapper = mount(StrategiesTable, {propsData: {strategies}});
         expect(wrapper.find(BTable).exists()).toBe(true);
         expect(wrapper.findAll("tbody tr").length).toBe(2);
         expect(wrapper.findAll("th").length).toBe(6);
@@ -37,6 +35,29 @@ describe("strategies table", () => {
         expect(row1.at(3).classes()).toContain("table-warning");
         expect(row1.at(4).text()).toBe("100");
         expect(row1.at(5).text()).toBe("$1,000");
+    });
+
+    it("emits strategy-selected event", () => {
+        const items = [
+            {
+                maximum_cost_vs_budget: '100%'
+            },
+            {
+                maximum_cost_vs_budget: '95%'
+            }
+        ];
+        const wrapper = shallowMount(StrategiesTable, {
+            propsData: {
+                strategies
+            },
+            computed: {
+                items() {
+                    return items;
+                }
+            }
+        });
+        wrapper.find(BTable).vm.$emit("row-selected", [items[1]]);
+        expect(wrapper.emitted("strategy-selected")).toStrictEqual([[strategies[1]]])
     });
 
 });

--- a/src/app/static/src/tests/components/figures/strategise/strategyTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategyTable.test.ts
@@ -1,0 +1,90 @@
+import {mount} from "@vue/test-utils";
+import StrategyTable from "../../../../app/components/figures/strategise/strategyTable.vue";
+import {BTable} from "bootstrap-vue";
+import Vuex from "vuex";
+import {mockProject, mockRootState} from "../../../mocks";
+
+describe("strategy table", () => {
+
+    it("renders table", () => {
+        const store = new Vuex.Store({
+            state: mockRootState({
+                currentProject: mockProject("My Project", ["Avalon", "Atlantis", "Asgard"])
+            })
+        });
+        store.state.currentProject!.regions[0].baselineSettings["population"] = 1000;
+        store.state.currentProject!.regions[1].baselineSettings["population"] = 2000;
+        store.state.currentProject!.regions[2].baselineSettings["population"] = 3000;
+        const wrapper = mount(StrategyTable, {
+            propsData: {
+                strategy: {
+                    costThreshold: 1,
+                    interventions: [
+                        {
+                            zone: "Avalon",
+                            intervention: "irs",
+                            cost: 500,
+                            casesAverted: 300
+                        },
+                        {
+                            zone: "Atlantis",
+                            intervention: "none",
+                            cost: 0,
+                            casesAverted: 0
+                        },
+                        {
+                            zone: "Asgard",
+                            intervention: "llin",
+                            cost: 750,
+                            casesAverted: 600
+                        }
+                    ]
+                }
+            },
+            store
+        });
+
+        expect(wrapper.find(BTable).exists()).toBe(true);
+        expect(wrapper.findAll("th").length).toBe(10);
+        expect(wrapper.findAll("tbody tr").length).toBe(4);
+
+        const firstRow = wrapper.findAll("tbody tr:first-child td");
+        expect(firstRow.at(0).text()).toBe("Avalon");
+        expect(firstRow.at(1).text()).toBe("IRS* only");
+        expect(firstRow.at(2).text()).toBe("1000");
+        expect(firstRow.at(3).text()).toBe("300");
+        expect(firstRow.at(4).text()).toBe("33.3%");
+        expect(firstRow.at(5).text()).toBe("$500");
+        expect(firstRow.at(6).text()).toBe("40%");
+        expect(firstRow.at(7).text()).toBe("$2");
+        expect(firstRow.at(8).text()).toBe("$0.5");
+        expect(firstRow.at(9).text()).toBe("0.3");
+        expect(firstRow.at(1).classes()).toContain("table-primary");
+
+        const secondRow = wrapper.findAll("tbody tr:nth-child(2) td");
+        expect(secondRow.at(0).text()).toBe("Atlantis");
+        expect(secondRow.at(1).text()).toBe("No intervention");
+        expect(secondRow.at(2).text()).toBe("2000");
+        expect(secondRow.at(3).text()).toBe("0");
+        expect(secondRow.at(4).text()).toBe("0%");
+        expect(secondRow.at(5).text()).toBe("$0");
+        expect(secondRow.at(6).text()).toBe("0%");
+        expect(secondRow.at(7).text()).toBe("NA");
+        expect(secondRow.at(8).text()).toBe("$0");
+        expect(secondRow.at(9).text()).toBe("0");
+        expect(secondRow.at(1).classes()).toHaveLength(0);
+
+        const lastRow = wrapper.findAll("tbody tr:last-child td");
+        expect(lastRow.at(0).text()).toBe("Total");
+        expect(lastRow.at(1).text()).toBe("");
+        expect(lastRow.at(2).text()).toBe("6000");
+        expect(lastRow.at(3).text()).toBe("900");
+        expect(lastRow.at(4).text()).toBe("100%");
+        expect(lastRow.at(5).text()).toBe("$1,250");
+        expect(lastRow.at(6).text()).toBe("100%");
+        expect(lastRow.at(7).text()).toBe("");
+        expect(lastRow.at(8).text()).toBe("");
+        expect(lastRow.at(9).text()).toBe("");
+    });
+
+});

--- a/src/app/static/src/tests/components/figures/strategise/util.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/util.test.ts
@@ -1,0 +1,38 @@
+import {
+    formatCases,
+    formatCost,
+    formatPercentage, getInterventionColour,
+    getInterventionName
+} from "../../../../app/components/figures/strategise/util";
+
+describe("strategise utilities", () => {
+
+    it("formats invalid costs as NA", () => {
+        expect(formatCost(NaN)).toBe("NA");
+    });
+
+    it("formats valid costs as expected", () => {
+        expect(formatCost(12.345)).toBe("$12");
+        expect(formatCost(12.345, 2)).toBe("$12.35");
+    });
+
+    it("formats cases as expected", () => {
+        expect(formatCases(12.345)).toBe("12");
+        expect(formatCases(12.345, 1)).toBe("12.3");
+    });
+
+    it("formats percentages as expected", () => {
+        expect(formatPercentage(0.123)).toBe("12.3%");
+    });
+
+    it("gets intervention name", () => {
+        expect(getInterventionName("irs-llin")).toBe("Pyrethroid LLIN with IRS*");
+        expect(getInterventionName("none")).toBe("No intervention");
+    });
+
+    it("gets intervention colour", () => {
+        expect(getInterventionColour("irs-llin")).toBe("warning");
+        expect(getInterventionColour("none")).toBe("");
+    });
+
+})

--- a/src/app/static/src/tests/components/strategisePage.test.ts
+++ b/src/app/static/src/tests/components/strategisePage.test.ts
@@ -1,4 +1,4 @@
-import {mount} from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import StrategisePage from "../../app/components/strategisePage.vue";
 import Vuex from "vuex";
 import {RootAction} from "../../app/actions";
@@ -94,6 +94,21 @@ describe("strategise page", () => {
         expect(alert.findAll("dl").length).toBe(1);
         expect(alert.find("dl dt").text()).toBe("OTHER_ERROR");
         expect(alert.find("dl dd").text()).toBe("DETAIL");
+    });
+
+    it("handles strategy selection", () => {
+        const strategy = {
+            costThreshold: 1,
+            interventions: [
+                {zone: "Region A", intervention: "irs-llin-pbo", casesAverted: 60, cost: 600},
+                {zone: "Region B", intervention: "irs-llin", casesAverted: 40, cost: 400}
+            ]
+        };
+        const store = createStore();
+        store.state.currentProject!.strategies = [strategy];
+        const wrapper = shallowMount(StrategisePage, {store});
+        wrapper.find(strategiesTable).vm.$emit("strategy-selected", strategy);
+        expect(wrapper.vm.$data.selectedStrategy).toBe(strategy);
     });
 
 });

--- a/src/app/static/src/tests/e2e/mint.etest.ts
+++ b/src/app/static/src/tests/e2e/mint.etest.ts
@@ -1,21 +1,20 @@
 import {expect, test} from "@playwright/test";
 
 test.describe("basic tests", () => {
+
     test("renders homepage", async ({page}) => {
         await page.goto("/");
-        const name = await page.innerText("a.navbar-brand");
-        expect(name).toBe("MINT");
+
+        expect(await page.innerText("a.navbar-brand")).toBe("MINT");
     });
 
     test("creates a project with two regions", async ({page}) => {
         await page.goto("/");
 
-        expect(await page.innerText("h1")).toBe("Create a project to get started");
         await page.fill("#name", "Project 1");
+
         await page.fill(".ti-new-tag-input", "Region A");
         await page.click(".btn-primary");
-
-        expect(await page.innerText("h4")).toBe("Setup baseline");
         await page.click("text=Next");
 
         expect(await page.innerText(":nth-match(a.active, 1)")).toBe("Impact");
@@ -53,6 +52,13 @@ test.describe("basic tests", () => {
         await page.click("#stratAcrossRegions");
         await page.click(".btn-primary");
 
-        expect(await page.innerText(".table")).toContain("Pyrethroid-PBO ITN only");
+        expect(await page.innerText(".summaryTable")).toContain("Pyrethroid-PBO ITN only");
+
+        // Select row in summary table in order to see details for a specific strategy
+        await page.click("text='Strategy 3'");
+
+        // Check for the total population across the two regions, displayed in summary row
+        expect(await page.innerText(".detailsTable")).toContain("2000");
     });
+
 });


### PR DESCRIPTION
* Add new details table on strategise page
* To test, follow instructions in #95, then select a row in the summary table
* Share utils between summary and details tables
* Tab pane for switching between table and (as yet unimplemented) charts will be added in mrc-2493
* Cell colours in summary table are overridden by selected row styling. Ideally we could set the opacity of the row while retaining the cell formatting. Cell formatting actually used to take precedence in `b-table` but [was changed](https://github.com/bootstrap-vue/bootstrap-vue/issues/3008#issuecomment-533730844). The colours are duplicated in the details table so this isn't a huge issue. Alternative may be to simply add border around existing row, as below. Have tried to implement this but not trivial. Should be possible though. Will seek feedback from science team on what they prefer.
![Screenshot from 2021-08-19 09-12-01](https://user-images.githubusercontent.com/1724545/130032753-bd930741-c840-47bc-a994-3de31956f20f.png)

