### PR TITLE
mrc-2591 Identify selected strategy more clearly

### DIFF
--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -1,5 +1,6 @@
 <template>
-  <b-table :items="items" hover selectable select-mode="single" @row-selected="onRowSelected"></b-table>
+  <b-table :items="items" hover selectable select-mode="single" @row-selected="onRowSelected"
+           selected-variant=""></b-table>
 </template>
 
 <script lang="ts">

--- a/src/app/static/src/app/components/strategisePage.vue
+++ b/src/app/static/src/app/components/strategisePage.vue
@@ -36,19 +36,14 @@
         <b-button type="submit" variant="primary">Strategize</b-button>
       </b-form>
     </div>
-    <div class="results mt-5">
-      <loading-spinner v-if="strategising" size="lg" class="mx-auto"></loading-spinner>
-      <strategies-table v-if="strategies.length" :strategies="strategies"
-                        @strategy-selected="onStrategySelected" class="summaryTable"></strategies-table>
-      <b-alert :show="errors.length > 0" variant="danger" dismissible @dismissed="dismissErrors">
-        <h5 class="alert-heading">Errors occurred when strategizing</h5>
-        <dl v-for="(error, index) in errors" :key="index">
-          <dt>{{ error.error }}</dt>
-          <dd v-if="error.detail">{{ error.detail }}</dd>
-        </dl>
-      </b-alert>
-      <div class="mt-5" v-if="strategies.length">
+    <div class="results">
+      <loading-spinner v-if="strategising" size="lg" class="mx-auto mt-4"></loading-spinner>
+      <div v-if="strategies.length">
+        <h2 class="h4 text-center mt-5">All strategies</h2>
+        <strategies-table :strategies="strategies"
+                          @strategy-selected="onStrategySelected" class="summaryTable"></strategies-table>
         <div v-if="selectedStrategy">
+          <h2 class="h4 text-center mt-5">Details for Strategy {{ strategies.indexOf(selectedStrategy) + 1 }}</h2>
           <ul class="nav nav-tabs">
             <li class="nav-item">
               <a class="text-success nav-link" :class="{active: activeTab === 'charts'}" @click="activeTab = 'charts'">Charts</a>
@@ -63,8 +58,16 @@
                             class="detailsTable"></strategy-table>
           </div>
         </div>
-        <h2 v-else class="h4 text-center">Select a row in the table above to see details of the selected strategy</h2>
+        <h2 v-else class="h4 text-center mt-5">Select a row in the table above to see details of the selected
+          strategy</h2>
       </div>
+      <b-alert :show="errors.length > 0" variant="danger" dismissible @dismissed="dismissErrors">
+        <h5 class="alert-heading">Errors occurred when strategizing</h5>
+        <dl v-for="(error, index) in errors" :key="index">
+          <dt>{{ error.error }}</dt>
+          <dd v-if="error.detail">{{ error.detail }}</dd>
+        </dl>
+      </b-alert>
     </div>
   </div>
 </template>

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -37,6 +37,10 @@
         font-weight: 700;
         white-space: nowrap;
       }
+
+      .b-table-row-selected {
+        border: solid gray;
+      }
     }
 
     .detailsTable {

--- a/src/app/static/src/tests/components/strategisePage.test.ts
+++ b/src/app/static/src/tests/components/strategisePage.test.ts
@@ -88,7 +88,7 @@ describe("strategise page", () => {
         expect(wrapper.vm.$data.selectedStrategy).toBeNull();
     });
 
-    it("displays table", async () => {
+    it("displays table with heading", async () => {
         const store = createStore();
         const wrapper = mount(StrategisePage, {store});
         expect(wrapper.find(strategiesTable).exists()).toBe(false);
@@ -102,6 +102,7 @@ describe("strategise page", () => {
             }
         ];
         await Vue.nextTick();
+        expect(wrapper.find("h2").text()).toBe("All strategies");
         expect(wrapper.find(strategiesTable).exists()).toBe(true);
     });
 
@@ -126,15 +127,21 @@ describe("strategise page", () => {
         const store = createStore();
         store.state.currentProject!.strategies = [strategy];
         const wrapper = shallowMount(StrategisePage, {store});
+
+        await Vue.nextTick();
+
+        expect(wrapper.findAll("h2").at(1).text()).toContain("Select a row");
+
         wrapper.find(strategiesTable).vm.$emit("strategy-selected", strategy);
         expect(wrapper.vm.$data.selectedStrategy).toBe(strategy);
 
         await Vue.nextTick();
 
-        expect(wrapper.findAll(".nav-tabs a.active").length).toBe(1);
-
+        expect(wrapper.findAll("h2").at(1).text()).toBe("Details for Strategy 1");
         expect(wrapper.find(strategyCharts).isVisible()).toBe(true);
         expect(wrapper.find(strategyTable).exists()).toBe(false);
+
+        expect(wrapper.findAll(".nav-tabs a.active").length).toBe(1);
 
         await wrapper.findAll(".nav-tabs a").at(1).trigger("click");
 

--- a/src/app/static/src/tests/e2e/mint.etest.ts
+++ b/src/app/static/src/tests/e2e/mint.etest.ts
@@ -55,8 +55,19 @@ test.describe("basic tests", () => {
         // Summary table should be displayed, with llin-pbo as at least one of the strategies
         expect(await page.innerText(".summaryTable")).toContain("Pyrethroid-PBO ITN only");
 
+        // Ensure that heading prompts strategy selection
+        expect(await page.innerText("h2 >> nth=1")).toContain("Select a row");
+
         // Select row in summary table in order to see details for a specific strategy
         await page.click("text='Strategy 3'");
+
+        // Ensure that heading reflects strategy selection
+        expect(await page.innerText("h2 >> nth=1")).toBe("Details for Strategy 3");
+
+        // Check that (only) the selected table row has a border
+        const border = async (selector) => page.$eval(selector, el => window.getComputedStyle(el).border);
+        expect(await border("tr:nth-child(3)")).toContain("solid");
+        expect(await border("tr:nth-child(2)")).toContain("none");
 
         // Verify default "Charts" tab is displayed by checking for title displayed above charts
         expect(await page.innerText(".tab-content")).toContain("Cases averted per region");


### PR DESCRIPTION
As agreed with science team:
- Remove `BTable` default highlighting style i.e. dark gray background that occludes per-strategy colour-coding
- Replace with a solid grey border and a heading that clearly indicates which strategy's details are being shown in the details table
- Update tests accordingly

 To test, folow instructions in #95, then select a row in the summary table