### PR TITLE
mrc-2597 Strategize: round cases averted and cost per case averted to nearest 50

### DIFF
--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -7,7 +7,13 @@
 import {BTable} from "bootstrap-vue";
 import Vue from "vue";
 import {StrategyWithThreshold} from "../../../models/project";
-import {formatCases, formatCost, getInterventionColourName, getInterventionName} from "./util";
+import {
+  roundNumberToNearest,
+  formatCurrency,
+  formatNumber,
+  getInterventionColourName,
+  getInterventionName
+} from "./util";
 
 interface Methods {
   onRowSelected: (rows: Record<string, any>[]) => void
@@ -42,8 +48,8 @@ export default Vue.extend<void, Methods, Computed, Props>({
           ...a,
           [intervention.zone]: getInterventionName(intervention.intervention)
         }), {}),
-        total_cases_averted: formatCases(strategy.interventions.reduce((a, intervention) => a + intervention.casesAverted, 0)),
-        total_cost: formatCost(strategy.interventions.reduce((a, intervention) => a + intervention.cost, 0)),
+        total_cases_averted: formatNumber(roundNumberToNearest(strategy.interventions.reduce((a, intervention) => a + intervention.casesAverted, 0), 50)),
+        total_cost: formatCurrency(roundNumberToNearest(strategy.interventions.reduce((a, intervention) => a + intervention.cost, 0), 50)),
         _cellVariants: strategy.interventions.reduce((a, intervention) => ({
           ...a,
           [intervention.zone]: getInterventionColourName(intervention.intervention)

--- a/src/app/static/src/app/components/figures/strategise/strategyCharts.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategyCharts.vue
@@ -6,7 +6,7 @@
 import Vue from "vue";
 import {StrategyWithThreshold} from "../../../models/project";
 import Plotly from "../graphs/plotly/Plotly.vue";
-import {formatCases, getInterventionColourValue, getInterventionName, getRegionPopulations} from "./util";
+import {formatNumber, getInterventionColourValue, getInterventionName, getRegionPopulations} from "./util";
 
 interface Data {
   layout: Record<string, any>
@@ -74,7 +74,7 @@ export default Vue.extend<Data, unknown, Computed, Props>({
               type: "bar",
               x: [intervention.zone],
               xaxis: "x",
-              y: [formatCases(intervention.casesAverted)],
+              y: [formatNumber(intervention.casesAverted)],
               yaxis: "y"
             },
             {
@@ -86,7 +86,7 @@ export default Vue.extend<Data, unknown, Computed, Props>({
               type: "bar",
               x: [intervention.zone],
               xaxis: "x2",
-              y: [formatCases(intervention.casesAverted / this.populations[intervention.zone], 1)],
+              y: [formatNumber(intervention.casesAverted / this.populations[intervention.zone], 1)],
               yaxis: "y2"
             }
           ]

--- a/src/app/static/src/app/components/figures/strategise/strategyTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategyTable.vue
@@ -7,8 +7,8 @@ import Vue from "vue";
 import {StrategyWithThreshold} from "../../../models/project";
 import {BTable} from "bootstrap-vue";
 import {
-  formatCases,
-  formatCost,
+  formatCurrency,
+  formatNumber,
   formatPercentage,
   getInterventionColourName,
   getInterventionName,
@@ -44,13 +44,13 @@ export default Vue.extend<unknown, unknown, Computed, Props>({
           region: intervention.zone,
           intervention: getInterventionName(intervention.intervention),
           population: String(population),
-          total_cases_averted: formatCases(intervention.casesAverted),
+          total_cases_averted: formatNumber(intervention.casesAverted),
           percentage_of_total_cases_averted: formatPercentage(intervention.casesAverted / totalCasesAverted),
-          total_costs: formatCost(intervention.cost),
+          total_costs: formatCurrency(intervention.cost),
           percentage_of_total_costs: formatPercentage(intervention.cost / totalCost),
-          cost_per_case_averted: formatCost(intervention.cost / intervention.casesAverted),
-          cost_per_person: formatCost(intervention.cost / population, 2),
-          cases_averted_per_person: formatCases(intervention.casesAverted / population, 1),
+          cost_per_case_averted: formatCurrency(intervention.cost / intervention.casesAverted),
+          cost_per_person: formatCurrency(intervention.cost / population, 2),
+          cases_averted_per_person: formatNumber(intervention.casesAverted / population, 1),
           _cellVariants: {
             intervention: getInterventionColourName(intervention.intervention)
           }
@@ -59,9 +59,9 @@ export default Vue.extend<unknown, unknown, Computed, Props>({
         region: "Total",
         intervention: "",
         population: String(Object.values(this.populations).reduce((a, population) => a + population, 0)),
-        total_cases_averted: formatCases(totalCasesAverted),
+        total_cases_averted: formatNumber(totalCasesAverted),
         percentage_of_total_cases_averted: "100%",
-        total_costs: formatCost(totalCost),
+        total_costs: formatCurrency(totalCost),
         percentage_of_total_costs: "100%",
         cost_per_case_averted: "",
         cost_per_person: "",

--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -6,21 +6,23 @@ export const getRegionPopulations = (project: Project) => project.regions.reduce
     {}
 );
 
-export const formatCost = (cost: number, maximumFractionDigits = 0) => isNaN(cost) ? "NA" : new Intl.NumberFormat('en-US', {
+export const formatCurrency = (cost: number, maximumFractionDigits = 0) => isNaN(cost) ? "NA" : new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 0,
     maximumFractionDigits
 }).format(cost);
 
-export const formatCases = (cases: number, maximumFractionDigits = 0) => new Intl.NumberFormat('en-US', {
+export const formatNumber = (value: number, maximumFractionDigits = 0) => new Intl.NumberFormat('en-US', {
     maximumFractionDigits
-}).format(cases);
+}).format(value);
 
 export const formatPercentage = (percentage: number) => new Intl.NumberFormat('en-US', {
     style: 'percent',
     maximumFractionDigits: 1
 }).format(percentage);
+
+export const roundNumberToNearest = (value: number, nearest: number) => Math.round(value / nearest) * nearest;
 
 const interventionNames: Record<string, string> = {
     "irs": "IRS* only",

--- a/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
@@ -8,8 +8,8 @@ describe("strategies table", () => {
         {
             costThreshold: 1,
             interventions: [
-                {zone: "Region A", intervention: "irs-llin-pbo", casesAverted: 60, cost: 600},
-                {zone: "Region B", intervention: "irs-llin", casesAverted: 40, cost: 400}
+                {zone: "Region A", intervention: "irs-llin-pbo", casesAverted: 60, cost: 615},
+                {zone: "Region B", intervention: "irs-llin", casesAverted: 45, cost: 400}
             ]
         },
         {
@@ -33,8 +33,8 @@ describe("strategies table", () => {
         expect(row1.at(2).classes()).toContain("table-danger");
         expect(row1.at(3).text()).toBe("Pyrethroid LLIN with IRS*");
         expect(row1.at(3).classes()).toContain("table-warning");
-        expect(row1.at(4).text()).toBe("100");
-        expect(row1.at(5).text()).toBe("$1,000");
+        expect(row1.at(4).text()).toBe("100"); // 60 + 45 = 105, rounded to nearest 50
+        expect(row1.at(5).text()).toBe("$1,000"); // 615 + 400 = 1015, similarly rounded
     });
 
     it("emits strategy-selected event", () => {
@@ -57,7 +57,7 @@ describe("strategies table", () => {
             }
         });
         wrapper.find(BTable).vm.$emit("row-selected", [items[1]]);
-        expect(wrapper.emitted("strategy-selected")).toStrictEqual([[strategies[1]]])
+        expect(wrapper.emitted("strategy-selected")).toStrictEqual([[strategies[1]]]);
     });
 
 });

--- a/src/app/static/src/tests/components/figures/strategise/util.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/util.test.ts
@@ -1,6 +1,6 @@
 import {
-    formatCases,
-    formatCost,
+    roundNumberToNearest,
+    formatCurrency, formatNumber,
     formatPercentage,
     getInterventionColourName,
     getInterventionName,
@@ -12,21 +12,29 @@ import {DynamicFormData} from "@reside-ic/vue-dynamic-form";
 describe("strategise utilities", () => {
 
     it("formats invalid costs as NA", () => {
-        expect(formatCost(NaN)).toBe("NA");
+        expect(formatCurrency(NaN)).toBe("NA");
     });
 
     it("formats valid costs as expected", () => {
-        expect(formatCost(12.345)).toBe("$12");
-        expect(formatCost(12.345, 2)).toBe("$12.35");
+        expect(formatCurrency(12.345)).toBe("$12");
+        expect(formatCurrency(12.345, 2)).toBe("$12.35");
     });
 
-    it("formats cases as expected", () => {
-        expect(formatCases(12.345)).toBe("12");
-        expect(formatCases(12.345, 1)).toBe("12.3");
+    it("formats numbers as expected", () => {
+        expect(formatNumber(12.345)).toBe("12");
+        expect(formatNumber(12.345, 1)).toBe("12.3");
     });
 
     it("formats percentages as expected", () => {
         expect(formatPercentage(0.123)).toBe("12.3%");
+    });
+
+    it("rounds numbers as expected", () => {
+        expect(roundNumberToNearest(5, 50)).toBe(0);
+        expect(roundNumberToNearest(25, 50)).toBe(50);
+        expect(roundNumberToNearest(45, 50)).toBe(50);
+        expect(roundNumberToNearest(55, 50)).toBe(50);
+        expect(roundNumberToNearest(100, 50)).toBe(100);
     });
 
     it("gets intervention name", () => {


### PR DESCRIPTION
Round figures in summary detail to nearest 50 and $50 respectively. Note that as agreed with the science team this leaves the details table unchanged, so the totals from that table won't match the summary figures. This will inherently be less of an issue once we start displaying error values, but can always be addressed in final wash-up if necessary.

Also change `formatCases()` and `formatCost()` to more generic `formatNumber()` and `formatCurrency()` respectively, to match `formatPercentage()` and make it clear that they contain no logic intrinsically linked to cases or costs.

To test: follow instructions in #95, strategise with a budget of your choosing and observe rounded numbers in relevant two columns in summary table.