### PR TITLE
mrc-2610 Strategize: make budget increment $1000

### DIFF
--- a/src/app/static/src/app/components/strategisePage.vue
+++ b/src/app/static/src/app/components/strategisePage.vue
@@ -30,7 +30,7 @@
           <help-circle-icon></help-circle-icon>
         </span>
         <b-input-group prepend="$USD" class="mb-2 mr-sm-3 mb-sm-0">
-          <b-form-input id="inline-form-input-budget" :value="budget" @update="update" type="number" min="0"
+          <b-form-input id="inline-form-input-budget" :value="budget" @update="update" type="number" min="0" step="1000"
                         :number="true" :required="true"></b-form-input>
         </b-input-group>
         <b-button type="submit" variant="primary">Strategize</b-button>

--- a/src/app/static/src/tests/components/strategisePage.test.ts
+++ b/src/app/static/src/tests/components/strategisePage.test.ts
@@ -38,6 +38,7 @@ describe("strategise page", () => {
         const wrapper = mount(StrategisePage, {store});
         const input = wrapper.find("input").element as HTMLInputElement;
         expect(input.value).toBe("10000");
+        expect(input.getAttribute("step")).toBe("1000");
     });
 
     it("propagates budget change to project settings", async () => {


### PR DESCRIPTION
To test:
- Visit http://localhost:8080/?stratAcrossRegions=true
- Add at least two regions, each of which has at least one intervention configured i.e. >0% ITN and/or IRS (the optimiser will work with no interventions but will return very uninteresting results)
- Click on "Strategize across regions" in the toolbar
- Click on increment/decrement button for budget input and observe value change by $1000 rather than $1