### PR TITLE
mrc-2701 Fix colours in strategy details chart

### DIFF
--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -48,7 +48,7 @@ const interventionColourValues: Record<string, string> = {
     "llin-pbo": "e0fae0",
     "irs-llin-pbo": "ffe6b8",
     "llin": "bbf0fb",
-    "irs-llin": "bbf0fb",
+    "irs-llin": "f5c6cb",
     "none": ""
 };
 export const getInterventionColourValue = (intervention: string) => interventionColourValues[intervention];

--- a/src/app/static/src/tests/components/figures/strategise/strategyCharts.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategyCharts.test.ts
@@ -9,34 +9,55 @@ describe("strategy charts", () => {
     it("renders charts", () => {
         const store = new Vuex.Store({
             state: mockRootState({
-                currentProject: mockProject("My Project", ["Avalon", "Atlantis", "Asgard"])
+                currentProject: mockProject("My Project", ["Amber", "Ankh-Morpork", "Aramanth", "Asgard", "Atlantis", "Avalon"])
             })
         });
-        store.state.currentProject!.regions[0].baselineSettings["population"] = 1000;
-        store.state.currentProject!.regions[1].baselineSettings["population"] = 2000;
-        store.state.currentProject!.regions[2].baselineSettings["population"] = 3000;
+        store.state.currentProject!.regions[0].baselineSettings["population"] = 10;
+        store.state.currentProject!.regions[1].baselineSettings["population"] = 20;
+        store.state.currentProject!.regions[2].baselineSettings["population"] = 30;
+        store.state.currentProject!.regions[3].baselineSettings["population"] = 40;
+        store.state.currentProject!.regions[4].baselineSettings["population"] = 50;
+        store.state.currentProject!.regions[5].baselineSettings["population"] = 60;
         const wrapper = shallowMount(StrategyCharts, {
             propsData: {
                 strategy: {
                     costThreshold: 1,
                     interventions: [
                         {
-                            zone: "Avalon",
+                            zone: "Amber",
                             intervention: "irs",
-                            cost: 500,
-                            casesAverted: 300
+                            cost: 1000,
+                            casesAverted: 100
                         },
                         {
-                            zone: "Atlantis",
-                            intervention: "none",
-                            cost: 0,
-                            casesAverted: 0
+                            zone: "Ankh-Morpork",
+                            intervention: "llin-pbo",
+                            cost: 2000,
+                            casesAverted: 200
+                        },
+                        {
+                            zone: "Aramanth",
+                            intervention: "irs-llin-pbo",
+                            cost: 3000,
+                            casesAverted: 300
                         },
                         {
                             zone: "Asgard",
                             intervention: "llin",
-                            cost: 750,
-                            casesAverted: 600
+                            cost: 4000,
+                            casesAverted: 400
+                        },
+                        {
+                            zone: "Atlantis",
+                            intervention: "irs-llin",
+                            cost: 5000,
+                            casesAverted: 500
+                        },
+                        {
+                            zone: "Avalon",
+                            intervention: "none",
+                            cost: 0,
+                            casesAverted: 0
                         }
                     ]
                 }
@@ -61,68 +82,115 @@ describe("strategy charts", () => {
             }
         );
         expect(chart.props("data")).toStrictEqual(
-            [
-                {
-                    marker: {color: "dbb8db"},
-                    name: "IRS* only",
-                    showlegend: true,
-                    type: "bar",
-                    x: ["Avalon"],
-                    xaxis: "x",
-                    y: ["300"],
-                    yaxis: "y"
-                },
-                {
-                    marker: {color: "dbb8db"},
-                    name: "IRS* only",
-                    showlegend: false,
-                    type: "bar",
-                    x: ["Avalon"],
-                    xaxis: "x2",
-                    y: ["0.3"],
-                    yaxis: "y2"
-                },
-                {
-                    marker: {color: ""},
-                    name: "No intervention",
-                    showlegend: false,
-                    type: "bar",
-                    x: ["Atlantis"],
-                    xaxis: "x",
-                    y: ["0"],
-                    yaxis: "y"
-                },
-                {
-                    marker: {color: ""},
-                    name: "No intervention",
-                    showlegend: false,
-                    type: "bar",
-                    x: ["Atlantis"],
-                    xaxis: "x2",
-                    y: ["0"],
-                    yaxis: "y2"
-                },
-                {
-                    marker: {color: "bbf0fb"},
-                    name: "Pyrethroid LLIN only",
-                    showlegend: true,
-                    type: "bar",
-                    x: ["Asgard"],
-                    xaxis: "x",
-                    y: ["600"],
-                    yaxis: "y"
-                },
-                {
-                    marker: {color: "bbf0fb"},
-                    name: "Pyrethroid LLIN only",
-                    showlegend: false,
-                    type: "bar",
-                    x: ["Asgard"],
-                    xaxis: "x2",
-                    y: ["0.2"],
-                    yaxis: "y2"
-                }
-            ]
+            [{
+                "marker": {"color": "dbb8db"},
+                "name": "IRS* only",
+                "showlegend": true,
+                "type": "bar",
+                "x": ["Amber"],
+                "xaxis": "x",
+                "y": ["100"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": "dbb8db"},
+                "name": "IRS* only",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Amber"],
+                "xaxis": "x2",
+                "y": ["10"],
+                "yaxis": "y2"
+            }, {
+                "marker": {"color": "e0fae0"},
+                "name": "Pyrethroid-PBO ITN only",
+                "showlegend": true,
+                "type": "bar",
+                "x": ["Ankh-Morpork"],
+                "xaxis": "x",
+                "y": ["200"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": "e0fae0"},
+                "name": "Pyrethroid-PBO ITN only",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Ankh-Morpork"],
+                "xaxis": "x2",
+                "y": ["10"],
+                "yaxis": "y2"
+            }, {
+                "marker": {"color": "ffe6b8"},
+                "name": "Pyrethroid-PBO ITN with IRS*",
+                "showlegend": true,
+                "type": "bar",
+                "x": ["Aramanth"],
+                "xaxis": "x",
+                "y": ["300"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": "ffe6b8"},
+                "name": "Pyrethroid-PBO ITN with IRS*",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Aramanth"],
+                "xaxis": "x2",
+                "y": ["10"],
+                "yaxis": "y2"
+            }, {
+                "marker": {"color": "bbf0fb"},
+                "name": "Pyrethroid LLIN only",
+                "showlegend": true,
+                "type": "bar",
+                "x": ["Asgard"],
+                "xaxis": "x",
+                "y": ["400"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": "bbf0fb"},
+                "name": "Pyrethroid LLIN only",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Asgard"],
+                "xaxis": "x2",
+                "y": ["10"],
+                "yaxis": "y2"
+            }, {
+                "marker": {"color": "f5c6cb"},
+                "name": "Pyrethroid LLIN with IRS*",
+                "showlegend": true,
+                "type": "bar",
+                "x": ["Atlantis"],
+                "xaxis": "x",
+                "y": ["500"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": "f5c6cb"},
+                "name": "Pyrethroid LLIN with IRS*",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Atlantis"],
+                "xaxis": "x2",
+                "y": ["10"],
+                "yaxis": "y2"
+            }, {
+                "marker": {"color": ""},
+                "name": "No intervention",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Avalon"],
+                "xaxis": "x",
+                "y": ["0"],
+                "yaxis": "y"
+            }, {
+                "marker": {"color": ""},
+                "name": "No intervention",
+                "showlegend": false,
+                "type": "bar",
+                "x": ["Avalon"],
+                "xaxis": "x2",
+                "y": ["0"],
+                "yaxis": "y2"
+            }]
         );
     });
 


### PR DESCRIPTION
To test:
- Run `master` branch and visit http://localhost:8080/?stratAcrossRegions=true
- Add at least two regions, both with default settings except ITN population use 20% and IRS coverage 60%
- Click on "Strategize across regions" in the toolbar, strategise with a budget of $23000 and select first row in table
- Note discrepancy between colour of first region in table and in charts below
- Repeat using this branch (no need to recreate regions)