### PR TITLE
mrc-3053 Css changes to temporarily hide unwanted baseline options

### DIFF
--- a/src/app/static/src/scss/partials/baseline.scss
+++ b/src/app/static/src/scss/partials/baseline.scss
@@ -57,5 +57,17 @@
         text-align: left;
       }
     }
+
+    /* mrc-3053 - temporarily hide sprayInput control, and itnUsage 80% option */
+    & > div:nth-child(3) {  /* Past Vector Control */
+      select[name='itnUsage'] option:nth-child(5) { /* 80% setting for itnUsage */
+        display: none;
+      }
+
+      div.row:nth-child(2) {  /* sprayInput  */
+        display: none;
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Css to temporarily hide baseline options which are currently returning inaccurate results. These are sprayInput 80% and itnUsage 80%. Because there is only one other sprayInput value (0%), hide the whole control, not just the option, so default value of 0% is always used. 

Run this branch with mintr branch mrc-3053 to see the effect of both sets of changes for the ticket. 