### PR TITLE
mrc-4089 Add data summary to plotlyGraph

### DIFF
--- a/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
+++ b/src/app/static/src/app/components/figures/graphs/plotlyGraph.vue
@@ -1,6 +1,18 @@
 <template>
     <div :class="{hoverbelow: hoverBelow}">
         <plotly :data="dataSeries" :layout="transformedLayout" :display-mode-bar="true"></plotly>
+        <div hidden class="mint-plot-data-summary" v-if="dataSeries">
+          <div class="mint-plot-data-summary-series" v-for="series in dataSeries" :key="series.name"
+               :name="series.name"
+               :id="series.id"
+               :type="series.type"
+               :count="series.x.length"
+               :x-first="series.x.length ? series.x[0] : null"
+               :x-last="series.x.length ? series.x[series.x.length-1] : null"
+               :y-min="Math.min(...series.y)"
+               :y-max="Math.max(...series.y)"
+          ></div>
+        </div>
     </div>
 </template>
 <script lang="ts">

--- a/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
+++ b/src/app/static/src/tests/components/figures/plotlyGraph.test.ts
@@ -57,6 +57,20 @@ describe("plotly graph", () => {
             x: [1, 2, 3],
             y: [0.2315, 0.7949, 0.5171]
         });
+
+        const dataSummary = wrapper.find(".mint-plot-data-summary");
+        expect(dataSummary.attributes("hidden")).toBe("hidden");
+        const dataSummarySeries = dataSummary.findAll(".mint-plot-data-summary-series");
+        expect(dataSummarySeries.length).toBe(1);
+        const summary = dataSummarySeries.at(0);
+        expect(summary.attributes("name")).toBe("No intervention");
+        expect(summary.attributes("id")).toBe("none");
+        expect(summary.attributes("type")).toBe("lines");
+        expect(summary.attributes("count")).toBe("3");
+        expect(summary.attributes("x-first")).toBe("1");
+        expect(summary.attributes("x-last")).toBe("3");
+        expect(summary.attributes("y-min")).toBe("0.2315");
+        expect(summary.attributes("y-max")).toBe("0.7949");
     });
 
     it("renders wide format data graph", async () => {
@@ -117,6 +131,29 @@ describe("plotly graph", () => {
             x: ["PBO"],
             y: [500]
         });
+
+        const dataSummary = wrapper.find(".mint-plot-data-summary");
+        expect(dataSummary.attributes("hidden")).toBe("hidden");
+        const dataSummarySeries = dataSummary.findAll(".mint-plot-data-summary-series");
+        expect(dataSummarySeries.length).toBe(2);
+        const summary1 = dataSummarySeries.at(0);
+        expect(summary1.attributes("name")).toBe("Pyrethoid ITN");
+        expect(summary1.attributes("id")).toBe("ITN");
+        expect(summary1.attributes("type")).toBe("bar");
+        expect(summary1.attributes("count")).toBe("1");
+        expect(summary1.attributes("x-first")).toBe("ITN");
+        expect(summary1.attributes("x-first")).toBe("ITN");
+        expect(summary1.attributes("y-min")).toBe("1000");
+        expect(summary1.attributes("y-max")).toBe("1000");
+        const summary2 = dataSummarySeries.at(1);
+        expect(summary2.attributes("name")).toBe("Switch to Pyrethoid-PBO ITN");
+        expect(summary2.attributes("id")).toBe("PBO");
+        expect(summary2.attributes("type")).toBe("bar");
+        expect(summary2.attributes("count")).toBe("1");
+        expect(summary2.attributes("x-first")).toBe("PBO");
+        expect(summary2.attributes("x-first")).toBe("PBO");
+        expect(summary2.attributes("y-min")).toBe("500");
+        expect(summary2.attributes("y-max")).toBe("500");
     });
 
     it("uses transformed layout", () => {


### PR DESCRIPTION
To enable easier browser testing, add a WODIN-style hidden data summary to the plotly graph component.

Now deployed to mint-dev, along with mintr mrc-3999 and its mysteriously re-appearing cost effectiveness graph... 