### PR TITLE
mrc-4002 Support 0 values for settings, and treat empty as 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ app/static/coverage/**
 .gradle
 app/static/public/js/**
 app/static/public/css/**
+app/static/test-results
 ssl

--- a/src/app/static/playwright.config.ts
+++ b/src/app/static/playwright.config.ts
@@ -3,7 +3,8 @@ import {PlaywrightTestConfig} from '@playwright/test';
 const config: PlaywrightTestConfig = {
     testMatch: '*.etest.ts',
     use: {
-        baseURL: "http://localhost:8080"
+        baseURL: "http://localhost:8080",
+        screenshot: "only-on-failure"
     }
 };
 

--- a/src/app/static/playwright.config.ts
+++ b/src/app/static/playwright.config.ts
@@ -5,7 +5,8 @@ const config: PlaywrightTestConfig = {
     use: {
         baseURL: "http://localhost:8080",
         screenshot: "only-on-failure"
-    }
+    },
+    retries: 1
 };
 
 export default config;

--- a/src/app/static/src/app/components/figures/transformedData.ts
+++ b/src/app/static/src/app/components/figures/transformedData.ts
@@ -14,12 +14,17 @@ export function useTransformation(props: TransformationProps) {
                 let val;
                 if (props.settings && id in props.settings) {
                     val = props.settings[id].toString();
+
+                    // Default to 0 if text is cleared from numeric
+                    if (val === "") {
+                        val = "0";
+                    }
                 }
                 if (!val && row) {
                     val = row[id]
                 }
-                // Default to 0 if text is cleared from numeric
-                return val || "0";
+
+                return val;
             });
         try {
             return evaluate(interpolatedFormula);

--- a/src/app/static/src/app/components/figures/transformedData.ts
+++ b/src/app/static/src/app/components/figures/transformedData.ts
@@ -11,16 +11,22 @@ export function useTransformation(props: TransformationProps) {
         const interpolatedFormula = formula.replace(/\{([^}]+)\}/g,
             (match) => {
                 const id = match.replace(/\{|\}/g, "");
-                let val = "";
-                if (props.settings) {
-                    val = props.settings[id] as string;
+                let val;
+                if (props.settings && id in props.settings) {
+                    val = props.settings[id].toString();
                 }
                 if (!val && row) {
                     val = row[id]
                 }
-                return val
+                // Default to 0 if text is cleared from numeric
+                return val || "0";
             });
-        return evaluate(interpolatedFormula);
+        try {
+            return evaluate(interpolatedFormula);
+        } catch (e) {
+            console.log(`Unable to evaluate formula: "${formula}" which resolved to: ${interpolatedFormula}`);
+            throw e;
+        }
     };
     return {evaluateFormula}
 }

--- a/src/app/static/src/tests/components/figures/transformedData.test.ts
+++ b/src/app/static/src/tests/components/figures/transformedData.test.ts
@@ -15,6 +15,22 @@ describe("use transformation", () => {
         expect(evaluateFormula("{irsUse} + {netUse}")).toBe(3);
     });
 
+    it("can evaluate formulas with empty and zero settings", () => {
+
+        const props = {
+            settings: {
+                "irsUse": 1.5,
+                "netUse": 1.5,
+                "zero": 0,
+                "zeroStr": "0",
+                "empty": ""
+            }
+        }
+
+        const evaluateFormula = useTransformation(props).evaluateFormula;
+        expect(evaluateFormula("{irsUse} + {netUse} + {zero} + {zeroStr} + {empty}")).toBe(3);
+    });
+
     it("can evaluate formulas with no settings", () => {
 
         const props = {
@@ -25,4 +41,18 @@ describe("use transformation", () => {
         expect(evaluateFormula("1 + 2")).toBe(3);
     });
 
+    it("logs details if cannot transform formula", () => {
+        const consoleSpy = jest.spyOn(console, "log");
+        const props = {
+            settings: {
+                "irsUse": 1.5,
+                "netUse": "nonsense"
+            }
+        }
+
+        expect(() => useTransformation(props).evaluateFormula("{irsUse} + {netUse}"))
+            .toThrowError("Undefined symbol nonsense");
+        expect(consoleSpy)
+            .toHaveBeenCalledWith("Unable to evaluate formula: \"{irsUse} + {netUse}\" which resolved to: 1.5 + nonsense");
+    });
 });

--- a/src/app/static/src/tests/e2e/forms.etest.ts
+++ b/src/app/static/src/tests/e2e/forms.etest.ts
@@ -1,0 +1,51 @@
+import {expect, test} from "@playwright/test";
+
+const costStringToNumber = (costString) => {
+    const regex =  /\$([0-9.]*)(k?)/;
+    const match = costString.match(regex);
+    if (!match) {
+        return null;
+    }
+    const numericPart = Number.parseFloat(match[1]);
+    const kPart = match[2] ? 1000 : 1;
+    return numericPart * kPart;
+};
+test.beforeEach(async ({page}) => {
+    await page.goto("/");
+
+    // Make a project
+    await page.fill("#name", "Project 1");
+    await page.fill(".ti-new-tag-input", "Region A");
+    await page.click(".btn-primary");
+
+    // Accept baseline
+    await page.click("text=Next");
+
+    // select usages
+    await page.locator("select[name='netUse']").selectOption("0.2");
+    await page.locator("select[name='irsUse']").selectOption("0.6");
+
+    // Go to cost table
+    await page.click("text='Table'")
+    await page.click("text='Cost effectiveness'");
+});
+
+test("can set procurement buffer to 0", async ({page}) => {
+    // values in cost table should update accordingly
+    const llinRow = await page.locator(":nth-match(table tr, 4)");
+    const costCell = await llinRow.locator(":nth-match(td, 5)");
+    const originalLLINCost = costStringToNumber(await costCell.innerText());
+
+    const procureBufferInput = await page.locator("input[name='procureBuffer']");
+    await procureBufferInput.fill("0");
+
+    const newLLINCost = costStringToNumber(await costCell.innerText());
+    expect(newLLINCost).toBeLessThan(originalLLINCost);
+
+    // empty numeric value should be treated as 0
+    // reset value to ensure setting to empty makes  difference
+    await procureBufferInput.fill("7");
+    expect(costStringToNumber(await costCell.innerText())).toBe(originalLLINCost);
+    await procureBufferInput.fill("");
+    expect(costStringToNumber(await costCell.innerText())).toBe(newLLINCost);
+});


### PR DESCRIPTION
This branch should fix the bug reported that the cost table 'disappeared' if the procurement buffer intervention setting was set to 0. When I reproduced this, the table didn't disppear, but it did stop updating any values. An error was occurring because the zero value was being cast to string 'undefined' which could not be evaluated. I've changed the cast to explicitly call `toString`, and I've also made it treat empty strings as 0 (since the numeric inputs can be cleared). 

I've also put in a bit of extra logging if an error like this occurs to record the formula which could not be interpolated rather than rethrowing - this should help diagnose any further errors like this. 