### PR TITLE
mrc-4004 Fix sorting by total cost in Cost effectiveness table

### DIFF
--- a/src/app/static/src/app/components/figures/errorInterval.ts
+++ b/src/app/static/src/app/components/figures/errorInterval.ts
@@ -1,4 +1,4 @@
-interface ErrorInterval {
+export interface ErrorInterval {
     plus: number;
     minus: number;
 }

--- a/src/app/static/src/tests/components/figures/dynamicTable.test.ts
+++ b/src/app/static/src/tests/components/figures/dynamicTable.test.ts
@@ -273,4 +273,43 @@ describe("dynamic table", () => {
         expect(rows.at(2).findAll("td").at(2).find("abbr").attributes().title).toBe("2.0k +0.0 / -750.0");
 
     });
+
+    it("columns are sortable by value", async () => {
+        const data = [
+            {sortable_value: 3817283},
+            {sortable_value: 9219}
+        ];
+        const config: ColumnDefinition[] = [
+            {
+                displayName: "Sortable",
+                valueCol: "sortable_value",
+                format: "$0[.][00]a",
+                precision: 2
+            }
+        ];
+
+        const wrapper = mount(dynamicTable, {
+            propsData: {data, config, settings}
+        });
+        const rows = wrapper.findAll("tbody tr");
+
+        // initial ordering
+        expect(rows.at(0).find("td").text()).toBe("$3.8m");
+        expect(rows.at(1).find("td").text()).toBe("$9.2k");
+
+        // sort ascending
+        const sortSpan = wrapper.find("th span.sr-only");
+        await sortSpan.trigger("click");
+
+        let sortedRows = wrapper.findAll("tbody tr");
+        expect(sortedRows.at(0).find("td").text()).toBe("$9.2k");
+        expect(sortedRows.at(1).find("td").text()).toBe("$3.8m");
+
+        // sort descending
+        await sortSpan.trigger("click");
+
+        sortedRows = wrapper.findAll("tbody tr");
+        expect(sortedRows.at(0).find("td").text()).toBe("$3.8m");
+        expect(sortedRows.at(1).find("td").text()).toBe("$9.2k");
+    });
 });


### PR DESCRIPTION
If you clicked on the Total Costs header in the Cost effectiveness table, the values would be sorted alphabetically (e.g. $1.2m would come before $30.1k). This was because only the formatted values were being provided to the bootstrap table, not the raw numeric values. 

This branch provides the raw values to the table, along with a separate formatter function to maintain the correct formatting as defined in the column config. 

To test this, increase baseline population to 100,000 - this will give a mixture of $k and $m values in Total Costs.  
This branch is currently deployed to https://mint-dev.dide.ic.ac.uk so you should be able to test it there. 