### PR TITLE
mrc-3235 Strategise for pyrrole net type

### DIFF
--- a/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategiesTable.vue
@@ -13,7 +13,7 @@
     import {BTable} from "bootstrap-vue";
     import Vue from "vue";
     import {StrategyWithThreshold} from "../../../models/project";
-    import {formatCases, formatCost, getInterventionColourName, getInterventionName} from "./util";
+    import {formatCases, formatCost, getInterventionName} from "./util";
 
     interface Methods {
         onRowSelected: (rows: Record<string, any>[]) => void,
@@ -58,7 +58,7 @@
                     total_cost: formatCost(strategy.interventions.reduce((a, intervention) => a + intervention.cost, 0)),
                     _cellVariants: strategy.interventions.reduce((a, intervention) => ({
                         ...a,
-                        [intervention.zone]: getInterventionColourName(intervention.intervention)
+                        [intervention.zone]: intervention.intervention
                     }), {})
                 }));
             }

--- a/src/app/static/src/app/components/figures/strategise/strategyTable.vue
+++ b/src/app/static/src/app/components/figures/strategise/strategyTable.vue
@@ -38,7 +38,6 @@
         formatCases,
         formatCost,
         formatPercentage,
-        getInterventionColourName,
         getInterventionName,
         getRegionPopulations
     } from "./util";
@@ -106,7 +105,7 @@
                             maximum: intervention.casesAvertedErrorPlus / population
                         } as any,
                         _cellVariants: {
-                            intervention: getInterventionColourName(intervention.intervention)
+                            intervention: intervention.intervention
                         }
                     };
                 }).concat({

--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -23,7 +23,7 @@ export const formatPercentage = (percentage: number) => new Intl.NumberFormat("e
 }).format(percentage);
 
 const interventionNames: Record<string, string> = {
-    "irs": "IRS* only",
+    "irs": "IRS only",
     "llin-pbo": "Pyrethroid-PBO ITN only",
     "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS",
     "llin": "Pyrethroid-only ITN only",
@@ -33,18 +33,6 @@ const interventionNames: Record<string, string> = {
     "none": "No intervention"
 };
 export const getInterventionName = (intervention: string) => interventionNames[intervention];
-
-// BTable uses Bootstrap colour variants for styling: https://bootstrap-vue.org/docs/components/table#items-record-data
-/*const interventionColourNames: Record<string, string> = {
-    "irs": "primaryx",
-    "llin-pbo": "secondaryx",
-    "irs-llin-pbo": "dangerx",
-    "llin": "successx",
-    "irs-llin": "warningx",
-    "none": ""
-};
-export const getInterventionColourName = (intervention: string) => interventionColourNames[intervention];
-*/
 
 const interventionColourValues: Record<string, string> = {
     "irs": "c080c0",

--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -25,30 +25,35 @@ export const formatPercentage = (percentage: number) => new Intl.NumberFormat("e
 const interventionNames: Record<string, string> = {
     "irs": "IRS* only",
     "llin-pbo": "Pyrethroid-PBO ITN only",
-    "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS*",
-    "llin": "Pyrethroid LLIN only",
-    "irs-llin": "Pyrethroid LLIN with IRS*",
+    "irs-llin-pbo": "Pyrethroid-PBO ITN with IRS",
+    "llin": "Pyrethroid-only ITN only",
+    "irs-llin": "Pyrethroid-only ITN with IRS",
+    "pyrrole-pbo": "Pyrethroid-pyrrole ITN only",
+    "irs-pyrrole-pbo": "Pyrethroid-pyrrole ITN with IRS",
     "none": "No intervention"
 };
 export const getInterventionName = (intervention: string) => interventionNames[intervention];
 
 // BTable uses Bootstrap colour variants for styling: https://bootstrap-vue.org/docs/components/table#items-record-data
-const interventionColourNames: Record<string, string> = {
-    "irs": "primary",
-    "llin-pbo": "secondary",
-    "irs-llin-pbo": "danger",
-    "llin": "success",
-    "irs-llin": "warning",
+/*const interventionColourNames: Record<string, string> = {
+    "irs": "primaryx",
+    "llin-pbo": "secondaryx",
+    "irs-llin-pbo": "dangerx",
+    "llin": "successx",
+    "irs-llin": "warningx",
     "none": ""
 };
 export const getInterventionColourName = (intervention: string) => interventionColourNames[intervention];
+*/
 
 const interventionColourValues: Record<string, string> = {
-    "irs": "dbb8db",
-    "llin-pbo": "e0fae0",
-    "irs-llin-pbo": "ffe6b8",
-    "llin": "bbf0fb",
-    "irs-llin": "f5c6cb",
+    "irs": "c080c0",
+    "llin-pbo": "bfffea",
+    "pyrrole-pbo": "80b280",
+    "irs-llin-pbo": "ffd280",
+    "llin": "8080ff",
+    "irs-llin": "c58080",
+    "irs-pyrrole-pbo": "99e699",
     "none": ""
 };
 export const getInterventionColourValue = (intervention: string) => interventionColourValues[intervention];

--- a/src/app/static/src/app/components/figures/strategise/util.ts
+++ b/src/app/static/src/app/components/figures/strategise/util.ts
@@ -34,6 +34,8 @@ const interventionNames: Record<string, string> = {
 };
 export const getInterventionName = (intervention: string) => interventionNames[intervention];
 
+// These colour values used in the barcharts correspond to those defined for table cell backgrounds in strategise.scss -
+// colours should be updated in both places
 const interventionColourValues: Record<string, string> = {
     "irs": "c080c0",
     "llin-pbo": "bfffea",

--- a/src/app/static/src/app/featureSwitches.ts
+++ b/src/app/static/src/app/featureSwitches.ts
@@ -1,5 +1,5 @@
 const urlParams = new URLSearchParams(window.location.search);
-const stratAcrossRegions = !!urlParams.get("stratAcrossRegions");
+const stratAcrossRegions = !urlParams.get("stratAcrossRegions");
 export const switches = {
     stratAcrossRegions: stratAcrossRegions
 }

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -12,25 +12,13 @@
       display: block;
     }
 
-    .table-success {
-      background-color: #bbf0fb;
-    }
-
-    .table-secondary {
-      background-color: #e0fae0;
-    }
-
-    .table-primary {
-      background-color: #dbb8db;
-    }
-
-    .table-warning {
-      background-color: #f5c6cb;
-    }
-
-    .table-danger {
-      background-color: #ffe6b8;
-    }
+    .table-irs { background-color: #c080c0 }
+    .table-llin-pbo { background-color: #bfffea }
+    .table-pyrrole-pbo { background-color: #80b280 }
+    .table-irs-llin-pbo { background-color: #ffd280 }
+    .table-llin { background-color: #8080ff }
+    .table-irs-llin { background-color: #c58080 }
+    .table-irs-pyrrole-pbo { background-color: #99e699 }
 
     .summaryTable {
       tr td:first-child {

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -12,6 +12,8 @@
       display: block;
     }
 
+     // The following cell background colours correspond to the barchart colours defined in interventionColourValues in
+     // components/figures/strategise/util.ts - colours should be updated in both places
     .table-irs {
       background-color: #c080c0
     }

--- a/src/app/static/src/scss/partials/strategise.scss
+++ b/src/app/static/src/scss/partials/strategise.scss
@@ -12,13 +12,33 @@
       display: block;
     }
 
-    .table-irs { background-color: #c080c0 }
-    .table-llin-pbo { background-color: #bfffea }
-    .table-pyrrole-pbo { background-color: #80b280 }
-    .table-irs-llin-pbo { background-color: #ffd280 }
-    .table-llin { background-color: #8080ff }
-    .table-irs-llin { background-color: #c58080 }
-    .table-irs-pyrrole-pbo { background-color: #99e699 }
+    .table-irs {
+      background-color: #c080c0
+    }
+
+    .table-llin-pbo {
+      background-color: #bfffea
+    }
+
+    .table-pyrrole-pbo {
+      background-color: #80b280
+    }
+
+    .table-irs-llin-pbo {
+      background-color: #ffd280
+    }
+
+    .table-llin {
+      background-color: #8080ff
+    }
+
+    .table-irs-llin {
+      background-color: #c58080
+    }
+
+    .table-irs-pyrrole-pbo {
+      background-color: #99e699
+    }
 
     .summaryTable {
       tr td:first-child {

--- a/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategiesTable.test.ts
@@ -31,7 +31,7 @@ describe("strategies table", () => {
             interventions: [
                 {
                     zone: "Region A",
-                    intervention: "irs-llin-pbo",
+                    intervention: "irs",
                     casesAverted: 35,
                     casesAvertedErrorMinus: 30,
                     casesAvertedErrorPlus: 45,
@@ -39,11 +39,32 @@ describe("strategies table", () => {
                 },
                 {
                     zone: "Region B",
-                    intervention: "irs-llin",
+                    intervention: "irs-llin-pbo",
                     casesAverted: 15,
                     casesAvertedErrorMinus: 5,
                     casesAvertedErrorPlus: 20,
                     cost: 200
+                }
+            ]
+        },
+        {
+            costThreshold: 0.9,
+            interventions: [
+                {
+                    zone: "Region A",
+                    intervention: "pyrrole-pbo",
+                    casesAverted: 34,
+                    casesAvertedErrorMinus: 30,
+                    casesAvertedErrorPlus: 45,
+                    cost: 250
+                },
+                {
+                    zone: "Region B",
+                    intervention: "irs-pyrrole-pbo",
+                    casesAverted: 14,
+                    casesAvertedErrorMinus: 5,
+                    casesAvertedErrorPlus: 20,
+                    cost: 150
                 }
             ]
         }
@@ -52,18 +73,42 @@ describe("strategies table", () => {
     it("renders table", () => {
         const wrapper = mount(StrategiesTable, {propsData: {strategies}});
         expect(wrapper.find(BTable).exists()).toBe(true);
-        expect(wrapper.findAll("tbody tr").length).toBe(2);
+
         expect(wrapper.findAll("th").length).toBe(6);
-        const row1 = wrapper.findAll("tbody tr:first-child td");
+        const rows = wrapper.findAll("tbody tr");
+        expect(rows.length).toBe(3);
+        const row1 = rows.at(0).findAll("td");
         expect(row1.at(0).text()).toBe("Strategy 1");
         expect(row1.at(1).text()).toBe("100%");
-        expect(row1.at(2).text()).toBe("Pyrethroid-PBO ITN with IRS*");
-        expect(row1.at(2).classes()).toContain("table-danger");
-        expect(row1.at(3).text()).toBe("Pyrethroid LLIN with IRS*");
-        expect(row1.at(3).classes()).toContain("table-warning");
+        expect(row1.at(2).text()).toBe("Pyrethroid-PBO ITN with IRS");
+        expect(row1.at(2).classes()).toContain("table-irs-llin-pbo");
+        expect(row1.at(3).text()).toBe("Pyrethroid-only ITN with IRS");
+        expect(row1.at(3).classes()).toContain("table-irs-llin");
         expect(row1.at(4).text()).toBe("100");
         expect(row1.at(4).find("abbr").attributes("title")).toBe("100 +20 / -15");
         expect(row1.at(5).text()).toBe("$1,000");
+
+        const row2 = rows.at(1).findAll("td");
+        expect(row2.at(0).text()).toBe("Strategy 2");
+        expect(row2.at(1).text()).toBe("95%");
+        expect(row2.at(2).text()).toBe("IRS only");
+        expect(row2.at(2).classes()).toContain("table-irs");
+        expect(row2.at(3).text()).toBe("Pyrethroid-PBO ITN with IRS");
+        expect(row2.at(3).classes()).toContain("table-irs-llin-pbo");
+        expect(row2.at(4).text()).toBe("50");
+        expect(row2.at(4).find("abbr").attributes("title")).toBe("50 +15 / -15");
+        expect(row2.at(5).text()).toBe("$500");
+
+        const row3 = rows.at(2).findAll("td");
+        expect(row3.at(0).text()).toBe("Strategy 3");
+        expect(row3.at(1).text()).toBe("90%");
+        expect(row3.at(2).text()).toBe("Pyrethroid-pyrrole ITN only");
+        expect(row3.at(2).classes()).toContain("table-pyrrole-pbo");
+        expect(row3.at(3).text()).toBe("Pyrethroid-pyrrole ITN with IRS");
+        expect(row3.at(3).classes()).toContain("table-irs-pyrrole-pbo");
+        expect(row3.at(4).text()).toBe("48");
+        expect(row3.at(4).find("abbr").attributes("title")).toBe("48 +17 / -13");
+        expect(row3.at(5).text()).toBe("$400");
     });
 
     it("emits strategy-selected event", () => {

--- a/src/app/static/src/tests/components/figures/strategise/strategyCharts.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategyCharts.test.ts
@@ -104,8 +104,8 @@ describe("strategy charts", () => {
         expect(chart.props("data")).toStrictEqual(    [
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'dbb8db' },
-                    name: 'IRS* only',
+                    marker: { color: 'c080c0' },
+                    name: 'IRS only',
                     showlegend: true,
                     type: 'bar',
                     x: [ 'Amber' ],
@@ -115,8 +115,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["1.0"], arrayminus: ["2.0"] },
-                    marker: { color: 'dbb8db' },
-                    name: 'IRS* only',
+                    marker: { color: 'c080c0' },
+                    name: 'IRS only',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Amber' ],
@@ -126,7 +126,7 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'e0fae0' },
+                    marker: { color: 'bfffea' },
                     name: 'Pyrethroid-PBO ITN only',
                     showlegend: true,
                     type: 'bar',
@@ -137,7 +137,7 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["0.5"], arrayminus: ["1.0"] },
-                    marker: { color: 'e0fae0' },
+                    marker: { color: 'bfffea' },
                     name: 'Pyrethroid-PBO ITN only',
                     showlegend: false,
                     type: 'bar',
@@ -148,8 +148,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'ffe6b8' },
-                    name: 'Pyrethroid-PBO ITN with IRS*',
+                    marker: { color: 'ffd280' },
+                    name: 'Pyrethroid-PBO ITN with IRS',
                     showlegend: true,
                     type: 'bar',
                     x: [ 'Aramanth' ],
@@ -159,8 +159,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["0.3"], arrayminus: ["0.7"] },
-                    marker: { color: 'ffe6b8' },
-                    name: 'Pyrethroid-PBO ITN with IRS*',
+                    marker: { color: 'ffd280' },
+                    name: 'Pyrethroid-PBO ITN with IRS',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Aramanth' ],
@@ -170,8 +170,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'bbf0fb' },
-                    name: 'Pyrethroid LLIN only',
+                    marker: { color: '8080ff' },
+                    name: 'Pyrethroid-only ITN only',
                     showlegend: true,
                     type: 'bar',
                     x: [ 'Asgard' ],
@@ -181,8 +181,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["0.3"], arrayminus: ["0.5"] },
-                    marker: { color: 'bbf0fb' },
-                    name: 'Pyrethroid LLIN only',
+                    marker: { color: '8080ff' },
+                    name: 'Pyrethroid-only ITN only',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Asgard' ],
@@ -192,8 +192,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'f5c6cb' },
-                    name: 'Pyrethroid LLIN with IRS*',
+                    marker: { color: 'c58080' },
+                    name: 'Pyrethroid-only ITN with IRS',
                     showlegend: true,
                     type: 'bar',
                     x: [ 'Atlantis' ],
@@ -203,8 +203,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["0.2"], arrayminus: ["0.4"] },
-                    marker: { color: 'f5c6cb' },
-                    name: 'Pyrethroid LLIN with IRS*',
+                    marker: { color: 'c58080' },
+                    name: 'Pyrethroid-only ITN with IRS',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Atlantis' ],
@@ -236,8 +236,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["10"], arrayminus: ["20"] },
-                    marker: { color: 'bbf0fb' },
-                    name: 'Pyrethroid LLIN only',
+                    marker: { color: '8080ff' },
+                    name: 'Pyrethroid-only ITN only',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Asgard' ],
@@ -247,8 +247,8 @@ describe("strategy charts", () => {
                 },
                 {
                     error_y: { array: ["0.3"], arrayminus: ["0.5"] },
-                    marker: { color: 'bbf0fb' },
-                    name: 'Pyrethroid LLIN only',
+                    marker: { color: '8080ff' },
+                    name: 'Pyrethroid-only ITN only',
                     showlegend: false,
                     type: 'bar',
                     x: [ 'Asgard' ],

--- a/src/app/static/src/tests/components/figures/strategise/strategyTable.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/strategyTable.test.ts
@@ -56,7 +56,7 @@ describe("strategy table", () => {
 
         const firstRow = wrapper.findAll("tbody tr:first-child td");
         expect(firstRow.at(0).text()).toBe("Avalon");
-        expect(firstRow.at(1).text()).toBe("IRS* only");
+        expect(firstRow.at(1).text()).toBe("IRS only");
         expect(firstRow.at(2).text()).toBe("1000");
         expect(firstRow.at(3).text()).toBe("300");
         expect(firstRow.at(3).find("abbr").attributes("title")).toBe("300 +100 / -5");
@@ -69,7 +69,7 @@ describe("strategy table", () => {
         expect(firstRow.at(8).text()).toBe("$0.5");
         expect(firstRow.at(9).text()).toBe("0.3");
         expect(firstRow.at(9).find("abbr").attributes("title")).toBe("0.3 +0.1 / -0");
-        expect(firstRow.at(1).classes()).toContain("table-primary");
+        expect(firstRow.at(1).classes()).toContain("table-irs");
 
         const secondRow = wrapper.findAll("tbody tr:nth-child(2) td");
         expect(secondRow.at(0).text()).toBe("Atlantis");
@@ -82,7 +82,7 @@ describe("strategy table", () => {
         expect(secondRow.at(7).text()).toBe("NA");
         expect(secondRow.at(8).text()).toBe("$0");
         expect(secondRow.at(9).text()).toBe("0");
-        expect(secondRow.at(1).classes()).toHaveLength(0);
+        expect(secondRow.at(1).classes()).toContain("table-none");
 
         const lastRow = wrapper.findAll("tbody tr:last-child td");
         expect(lastRow.at(0).text()).toBe("Total");

--- a/src/app/static/src/tests/components/figures/strategise/util.test.ts
+++ b/src/app/static/src/tests/components/figures/strategise/util.test.ts
@@ -2,7 +2,7 @@ import {
     formatCases,
     formatCost,
     formatPercentage,
-    getInterventionColourName,
+    getInterventionColourValue,
     getInterventionName,
     getRegionPopulations
 } from "../../../../app/components/figures/strategise/util";
@@ -30,13 +30,23 @@ describe("strategise utilities", () => {
     });
 
     it("gets intervention name", () => {
-        expect(getInterventionName("irs-llin")).toBe("Pyrethroid LLIN with IRS*");
-        expect(getInterventionName("none")).toBe("No intervention");
+        expect(getInterventionName("irs")).toBe("IRS only");
+        expect(getInterventionName("llin-pbo")).toBe("Pyrethroid-PBO ITN only");
+        expect(getInterventionName("pyrrole-pbo")).toBe("Pyrethroid-pyrrole ITN only");
+        expect(getInterventionName("irs-llin-pbo")).toBe("Pyrethroid-PBO ITN with IRS");
+        expect(getInterventionName("llin")).toBe("Pyrethroid-only ITN only");
+        expect(getInterventionName("irs-llin")).toBe("Pyrethroid-only ITN with IRS");
+        expect(getInterventionName("irs-pyrrole-pbo")).toBe("Pyrethroid-pyrrole ITN with IRS");
     });
 
     it("gets intervention colour", () => {
-        expect(getInterventionColourName("irs-llin")).toBe("warning");
-        expect(getInterventionColourName("none")).toBe("");
+        expect(getInterventionColourValue("irs")).toBe("c080c0");
+        expect(getInterventionColourValue("llin-pbo")).toBe("bfffea");
+        expect(getInterventionColourValue("pyrrole-pbo")).toBe("80b280");
+        expect(getInterventionColourValue("irs-llin-pbo")).toBe("ffd280");
+        expect(getInterventionColourValue("llin")).toBe("8080ff");
+        expect(getInterventionColourValue("irs-llin")).toBe("c58080");
+        expect(getInterventionColourValue("irs-pyrrole-pbo")).toBe("99e699");
     });
 
     it("gets populations", () => {

--- a/src/app/static/src/tests/e2e/forms.etest.ts
+++ b/src/app/static/src/tests/e2e/forms.etest.ts
@@ -31,6 +31,9 @@ test.beforeEach(async ({page}) => {
 });
 
 test("can set procurement buffer to 0", async ({page}) => {
+    // Click on Interventions header to order by name
+    await page.locator(":nth-match(th div, 1)").click();
+
     // values in cost table should update accordingly
     const llinRow = await page.locator(":nth-match(table tr, 4)");
     const costCell = await llinRow.locator(":nth-match(td, 5)");

--- a/src/app/static/src/tests/e2e/mint.etest.ts
+++ b/src/app/static/src/tests/e2e/mint.etest.ts
@@ -55,6 +55,8 @@ test.describe("basic tests", () => {
     });
 
     test("strategise", async ({page}) => {
+        await page.goto("/");
+
         // Create project
         await page.fill("#name", "Project 1");
 

--- a/src/app/static/src/tests/e2e/mint.etest.ts
+++ b/src/app/static/src/tests/e2e/mint.etest.ts
@@ -55,8 +55,6 @@ test.describe("basic tests", () => {
     });
 
     test("strategise", async ({page}) => {
-        await page.goto("/?stratAcrossRegions=true");
-
         // Create project
         await page.fill("#name", "Project 1");
 

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-master
+mrc-3235

--- a/src/config/mintr_version
+++ b/src/config/mintr_version
@@ -1,1 +1,1 @@
-mrc-3235
+master


### PR DESCRIPTION
This branch:
- switches on the feature switch so that Strategise is available by default.
- supports pyrrole net strategy results. Previously, we were using bootstrap text classes (e.g. 'warning') rather spuriously to colour the backgrounds of the strategy table cell for each intervention. I realised that we don't need to do this, as the BTable will give the cell a `table-` class for whatever text you give, then we just need to style that class. I've updated the colours passed to the chart to reflect this change too. This allows the strategise intervention colouring to match the colours in the main region page. 

I seemed to need to fix up a unit test by clicking a table column to order it, so it seems an ordering change must have crept in there. I'll check what the preferred behaviour is with Tom.

I've also added a ticket to refresh Strategise results on page reload, as these misleadingly do not update if you navigate back having changed a value which could impact the Strategise result. 

This branch is deployed to mint-dev along with the corresponding mintr branch.  To test strategise, you need to have at least two separate regions with different settings. The pyrrole net tends to have similar outcomes to the cheaper nets, so to force that net as a recommended strategy you may find you need to drop its price and adjust your budget:
![image](https://user-images.githubusercontent.com/44669576/230043246-b167406c-eabb-4770-a219-3252fbc57021.png)


I'm also seeing some kind of weird results in Strategise e.g. >1 cases averted per person. Will look into that on the mintr side!
UPDATE: looks like > 1 cases averted per person is already possible on the existing production version. I'll just check with Tom about that. 