### PR TITLE
mrc-4170 Privacy statement

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/HomeController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 class HomeController(private val apiClient: APIClient,
                      private val appProperties: AppProperties) {
 
-    @GetMapping("/", "/projects/{project}/regions/{region}")
+    @GetMapping("/", "/projects/{project}/regions/{region}", "accessibility", "privacy")
     fun index(model: Model): String {
         model["title"] = appProperties.applicationTitle
         return "index"

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/CostTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/CostTests.kt
@@ -2,31 +2,30 @@ package org.imperial.mrc.mint.integration.endpoints
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.web.client.getForEntity
-import org.springframework.boot.test.web.client.postForEntity
 
 class CostTests: EndpointTests() {
 
     @Test
     fun `can get cost graph cases averted config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/cost/graph/cases-averted/config")
-        assertSuccess(responseEntity, "Graph")
+        assertSuccessfulValidJson(responseEntity, "Graph")
     }
 
     @Test
     fun `can get cost graph per case config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/cost/graph/per-case/config")
-        assertSuccess(responseEntity, "Graph")
+        assertSuccessfulValidJson(responseEntity, "Graph")
     }
 
     @Test
     fun `can get cost table config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/cost/table/config")
-        assertSuccess(responseEntity, "TableDefinition")
+        assertSuccessfulValidJson(responseEntity, "TableDefinition")
     }
 
     @Test
     fun `can get cost docs`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/cost/docs")
-        assertSuccess(responseEntity, "Docs")
+        assertSuccessfulValidJson(responseEntity, "Docs")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EndpointTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EndpointTests.kt
@@ -15,15 +15,20 @@ abstract class EndpointTests {
     @Autowired
     lateinit var testRestTemplate: TestRestTemplate
 
-    protected fun assertSuccess(responseEntity: ResponseEntity<String>,
-                                schemaName: String?) {
+    protected fun assertSuccess(responseEntity: ResponseEntity<String>) {
+        if (responseEntity.statusCode != HttpStatus.OK) {
+            Assertions.fail<String>("Expected OK response but got error: ${responseEntity.body}")
+        }
+    }
+
+    protected fun assertSuccessfulValidJson(responseEntity: ResponseEntity<String>,
+                                            schemaName: String?) {
 
         Assertions.assertThat(responseEntity.headers.contentType!!.toString())
                 .isEqualTo("application/json")
 
-        if (responseEntity.statusCode != HttpStatus.OK) {
-            Assertions.fail<String>("Expected OK response but got error: ${responseEntity.body}")
-        }
+        assertSuccess(responseEntity)
+
         if (schemaName != null) {
             JSONValidator().validateSuccess(responseEntity.body!!, schemaName)
         }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/HomeTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/HomeTests.kt
@@ -23,10 +23,10 @@ class HomeTests : EndpointTests() {
         responseEntity = testRestTemplate.getForEntity("/projects/p1/regions/r1")
         assertSuccess(responseEntity)
 
-        responseEntity = testRestTemplate.getForEntity<String>("accessibility")
+        responseEntity = testRestTemplate.getForEntity<String>("/accessibility")
         assertSuccess(responseEntity)
 
-        responseEntity = testRestTemplate.getForEntity<String>("privacy")
+        responseEntity = testRestTemplate.getForEntity<String>("/privacy")
         assertSuccess(responseEntity)
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/HomeTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/HomeTests.kt
@@ -12,21 +12,27 @@ class HomeTests : EndpointTests() {
     fun `can get table data`() {
         val responseEntity = testRestTemplate.postForEntity<String>("/table/data",
                 Settings.Baseline)
-        assertSuccess(responseEntity, "Data")
+        assertSuccessfulValidJson(responseEntity, "Data")
     }
 
     @Test
     fun `can get index page for valid vue routes`() {
         var responseEntity = testRestTemplate.getForEntity<String>("/")
-        assertThat(responseEntity.statusCodeValue).isEqualTo(200)
+        assertSuccess(responseEntity)
 
         responseEntity = testRestTemplate.getForEntity("/projects/p1/regions/r1")
-        assertThat(responseEntity.statusCodeValue).isEqualTo(200)
+        assertSuccess(responseEntity)
+
+        responseEntity = testRestTemplate.getForEntity<String>("accessibility")
+        assertSuccess(responseEntity)
+
+        responseEntity = testRestTemplate.getForEntity<String>("privacy")
+        assertSuccess(responseEntity)
     }
 
     @Test
     fun `can get version`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/version")
-        assertSuccess(responseEntity, "Version")
+        assertSuccessfulValidJson(responseEntity, "Version")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/ImpactTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/ImpactTests.kt
@@ -10,31 +10,31 @@ class ImpactTests: EndpointTests() {
     @Test
     fun `can get impact graph prevalence config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/impact/graph/prevalence/config")
-        assertSuccess(responseEntity, "Graph")
+        assertSuccessfulValidJson(responseEntity, "Graph")
     }
 
     @Test
     fun `can get impact cases config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/impact/graph/cases-averted/config")
-        assertSuccess(responseEntity, "Graph")
+        assertSuccessfulValidJson(responseEntity, "Graph")
     }
 
     @Test
     fun `can get impact graph prevalence data`() {
         val responseEntity = testRestTemplate.postForEntity<String>("/impact/graph/prevalence/data",
                 Settings.Baseline)
-        assertSuccess(responseEntity, "Data")
+        assertSuccessfulValidJson(responseEntity, "Data")
     }
 
     @Test
     fun `can get impact table config`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/impact/table/config")
-        assertSuccess(responseEntity, "TableDefinition")
+        assertSuccessfulValidJson(responseEntity, "TableDefinition")
     }
 
     @Test
     fun `can get impact docs`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/impact/docs")
-        assertSuccess(responseEntity, "Docs")
+        assertSuccessfulValidJson(responseEntity, "Docs")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/OptionTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/OptionTests.kt
@@ -8,12 +8,12 @@ class OptionTests: EndpointTests() {
     @Test
     fun `can get baseline options`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/baseline/options")
-        assertSuccess(responseEntity, "DynamicFormOptions")
+        assertSuccessfulValidJson(responseEntity, "DynamicFormOptions")
     }
 
     @Test
     fun `can get intervention options`() {
         val responseEntity = testRestTemplate.getForEntity<String>("/intervention/options")
-        assertSuccess(responseEntity, "DynamicFormOptions")
+        assertSuccessfulValidJson(responseEntity, "DynamicFormOptions")
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/StrategiseTests.kt
@@ -31,7 +31,7 @@ class StrategiseTests : EndpointTests() {
                         )
                 )
         )
-        assertSuccess(responseEntity, "Strategise")
+        assertSuccessfulValidJson(responseEntity, "Strategise")
     }
 
 }

--- a/src/app/static/src/app/components/app.vue
+++ b/src/app/static/src/app/components/app.vue
@@ -26,9 +26,17 @@
                 <li v-if="currentProject" class="nav-item">
                     <user-guide-links :short="true"/>
                 </li>
-                <li v-else class="nav-item">
-                    <router-link class="text-dark" to="/accessibility">Accessibility</router-link>
-                </li>
+                <template v-else>
+                    <li class="nav-item">
+                        <router-link class="text-dark" to="/accessibility">Accessibility</router-link>
+                    </li>
+                    <li>
+                        <span class="mx-2">|</span>
+                    </li>
+                    <li class="nav-item">
+                        <router-link class="text-dark" to="/privacy">Privacy</router-link>
+                    </li>
+                </template>
                 <li>
                     <span class="mx-2">|</span>
                 </li>

--- a/src/app/static/src/app/components/privacyPage.vue
+++ b/src/app/static/src/app/components/privacyPage.vue
@@ -1,0 +1,89 @@
+<template>
+    <div class="container mt-5">
+        <div class="row">
+            <div class="col">
+                <h1>Privacy notice for mint.dide.ic.ac.uk</h1>
+                <p>
+                    In accordance with data protection legislation and the privacy electronic communications regulations, the privacy notice will:
+                </p>
+                <ul>
+                    <li>inform you as to how we look after your personal data when you visit our websites;</li>
+                    <li>tell you about your privacy rights;</li>
+                    <li>tell you how the law protects you;</li>>
+                </ul>
+                <p>
+                  This policy is based on the <a href="https://www.imperial.ac.uk/about-the-site/privacy/" target="_blank" rel="noopener noreferrer">Imperial College privacy policy</a>.
+                </p>
+
+                <h2>What do we collect?</h2>
+                <p>If you use this application we will record:</p>
+                <ul>
+                    <li>Your IP address</li>
+                    <li>Browser version details</li>
+                    <li>Which areas of the website you visit</li>
+                </ul>
+                <p>No other personal data is kept on our servers.</p>
+
+                <h2>How we use your personal data</h2>
+                <p>
+                  We record this data to generate analytics reports on the usage of the site in order to improve it.
+                </p>
+
+                <h2>Where we store your data</h2>
+                <p>
+                  We store your data on our own servers based in London, UK
+                </p>
+
+                <h2>How we keep your data secure</h2>h2>
+                <p>
+                  We have put in place appropriate security measures to prevent your personal data from being accidentally lost, used or
+                  accessed in an unauthorised way, altered or disclosed. In addition, we limit access to your personal data to the
+                  administrators of MINT, who have a business need to know, and are subject to a duty of confidentiality.
+                </p>
+
+                <h2>How long will we use your personal data for?</h2>
+                <ul>
+                    <li>
+                      We will retain your personal data indefinitely to fulfil the purposes we collected it for, including for the purposes
+                      of satisfying any legal, accounting, or reporting requirements.
+                    </li>
+                    <li>We therefore will remove your data when the site is discontinued.</li>
+                    <li>We will remove your data when you request we do so.</li>
+                </ul>
+
+                <h2>Disclosing your information</h2>
+                <ul>
+                  <li>
+                    We may pass on your personal information if we have a legal obligation to do so, or if we have to enforce or apply our
+                    terms of use and other agreements.
+                  </li>
+                  <li>
+                    We will not share your information with any other organisation for marketing, market research, or any other commercial purposes.
+                  </li>
+                </ul>
+
+                <h2>Your rights</h2>
+                <ul>
+                    <li>
+                        You can find out what information we hold about you by submitting a subject access request to
+                        <a href="mailto:reside@imperial.ac.uk">reside@imperial.ac.uk</a> and ask us not to use the information we collect.
+                    </li>
+                    <li>
+                      You also have the right to have data erased if it is no longer necessary for the purpose for which it was originally
+                      collected/processed, or if there are no overriding legitimate grounds for the processing. This is sometimes known as 'the right to be forgotten'.
+                      To find out more, please see -
+                        <a href="https://www.imperial.ac.uk/admin-services/secretariat/information-governance/data-protection/internal-guidance/guide-10/" target="_blank">Guide 12 - Individual Rights | Administration and support services | Imperial College London</a>
+                    </li>
+                </ul>
+
+                <h2>Links to other websites</h2>
+                <p>
+                  The mint.dide.ic.ac.uk website may contain links to other websites. This privacy policy applies to mint.dide.ic.ac.uk
+                  only and doesn't cover other websites that we link to. These services have their own terms and conditions and privacy
+                  policies. If you do go to another website from this one, read the privacy policy on that website to find out what it
+                  does with your information.
+                </p>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/app/static/src/app/components/privacyPage.vue
+++ b/src/app/static/src/app/components/privacyPage.vue
@@ -9,7 +9,7 @@
                 <ul>
                     <li>inform you as to how we look after your personal data when you visit our websites;</li>
                     <li>tell you about your privacy rights;</li>
-                    <li>tell you how the law protects you;</li>>
+                    <li>tell you how the law protects you;</li>
                 </ul>
                 <p>
                   This policy is based on the <a href="https://www.imperial.ac.uk/about-the-site/privacy/" target="_blank" rel="noopener noreferrer">Imperial College privacy policy</a>.
@@ -34,7 +34,7 @@
                   We store your data on our own servers based in London, UK
                 </p>
 
-                <h2>How we keep your data secure</h2>h2>
+                <h2>How we keep your data secure</h2>
                 <p>
                   We have put in place appropriate security measures to prevent your personal data from being accidentally lost, used or
                   accessed in an unauthorised way, altered or disclosed. In addition, we limit access to your personal data to the

--- a/src/app/static/src/app/components/privacyPage.vue
+++ b/src/app/static/src/app/components/privacyPage.vue
@@ -44,7 +44,7 @@
                 <h2>How long will we use your personal data for?</h2>
                 <ul>
                     <li>
-                      We will retain your personal data indefinitely to fulfil the purposes we collected it for, including for the purposes
+                      We may retain your personal data indefinitely to fulfil the purposes we collected it for, including for the purposes
                       of satisfying any legal, accounting, or reporting requirements.
                     </li>
                     <li>We therefore will remove your data when the site is discontinued.</li>

--- a/src/app/static/src/app/router.ts
+++ b/src/app/static/src/app/router.ts
@@ -1,7 +1,8 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 import projectListPage from "./components/projectListPage.vue";
-import accessibilityPage from "./components/accessibilityPage.vue"
+import accessibilityPage from "./components/accessibilityPage.vue";
+import privacyPage from "./components/privacyPage.vue";
 
 const regionPage = () => import("./components/regionPage.vue");
 const strategisePage = () => import("./components/strategisePage.vue");
@@ -10,6 +11,7 @@ const routes = [
     {path: "/", component: projectListPage},
     {path: "/projects/:project/regions/:region", component: regionPage},
     {path: "/accessibility", component: accessibilityPage},
+    {path: "/privacy", component: privacyPage},
     {path: "/strategise", component: strategisePage}
 ];
 

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -53,6 +53,13 @@ describe("app", () => {
         expect(wrapper.findAll(".navbar-nav.mr-auto").length).toBe(0);
     });
 
+    it("shows accessibility and privacy links if currentProject is null", () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find("router-link-stub[to='/accessibility']").text()).toBe("Accessibility");
+        expect(wrapper.find("router-link-stub[to='/privacy']").text()).toBe("Privacy");
+    });
+
     it("renders versions drop-down", () => {
         const wrapper = getWrapper();
         expect(wrapper.getComponent(VersionDropDown).exists()).toBe(true);

--- a/src/app/static/src/tests/components/privacyPage.test.ts
+++ b/src/app/static/src/tests/components/privacyPage.test.ts
@@ -1,0 +1,9 @@
+import PrivacyPage from "../../app/components/privacyPage.vue";
+import {mount} from "@vue/test-utils";
+
+describe("Privacy Page", ()=> {
+    it("renders as expected", () => {
+        const wrapper = mount(PrivacyPage);
+        expect(wrapper.find("h1").text()).toBe("Privacy notice for mint.dide.ic.ac.uk");
+    });
+});

--- a/src/app/static/src/tests/e2e/mint.etest.ts
+++ b/src/app/static/src/tests/e2e/mint.etest.ts
@@ -124,4 +124,27 @@ test.describe("basic tests", () => {
         expect(await page.innerText(".tab-content")).toContain("2000");
     });
 
+    test("accessibility page", async ({page}) => {
+        const expectedHeader = "Accessibility on MINT";
+        // can browse directly
+        await page.goto("/accessibility");
+        await expect(await page.innerText("h1")).toBe(expectedHeader);
+
+        // can follow link from nav bar
+        await page.goto("/");
+        await page.click("a[href='/accessibility']");
+        await expect(await page.innerText("h1")).toBe(expectedHeader);
+    });
+
+    test("privacy page", async ({page}) => {
+        const expectedHeader = "Privacy notice for mint.dide.ic.ac.uk";
+        // can browse directly
+        await page.goto("/privacy");
+        await expect(await page.innerText("h1")).toBe(expectedHeader);
+
+        // can follow link from nav bar
+        await page.goto("/");
+        await page.click("a[href='/privacy']");
+        await expect(await page.innerText("h1")).toBe(expectedHeader);
+    });
 });


### PR DESCRIPTION
This branch adds a Privacy statement, linked from the navbar on the landing page (next to the Accessibility link). The text of the statement is based on the corresponding statement in HINT. 

I've also enabled reloading the Accessibility and Privacy pages by defining those routes in the `HomeController` in the back end. I also noticed that reload on the Strategise page fails - that's going to be trickier to fix, so have created a ticket: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4193/

This branch has been deployed to mint-dev, and the privacy notice can be viewed here: https://mint-dev.dide.ic.ac.uk/privacy