### PR TITLE
mrc-4764: Proxy emulator data through the MINT backend.

### DIFF
--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -18,4 +18,5 @@ docker pull $MINTR_IMAGE
 docker run --rm -d \
   --network=$NETWORK \
   --name=$API \
-  -p 8888:8888 $MINTR_IMAGE
+  -v $HERE/../testdata/emulator:/emulator \
+  -p 8888:8888 $MINTR_IMAGE --emulator=/emulator

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -1,28 +1,10 @@
-buildscript {
-    ext.kotlin_version = '1.9.21'
-}
-
 apply plugin: 'application'
 
-mainClassName = "org.imperial.mrc.mint.AppStartKt"
-
-jacoco {
-    toolVersion = "0.8.11"
-    reportsDirectory = file("$projectDir/coverage")
+application {
+    mainClass = "org.imperial.mrc.mint.AppStartKt"
 }
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        csv.required = false
-    }
-}
-
-group = 'org.imperial.mrc'
-sourceCompatibility = '1.8'
 
 dependencies {
-
     implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
     implementation 'com.github.kittinunf.fuel:fuel-json:2.3.1'
     implementation 'com.github.kittinunf.fuel:fuel-coroutines:2.3.1'

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/Extensions.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/Extensions.kt
@@ -8,15 +8,16 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import java.io.IOException
 
-@Suppress("UNCHECKED_CAST", "SwallowedException")
-fun Response.asResponseEntity(): ResponseEntity<String> {
-    val httpStatus = httpStatusFromCode(this.statusCode)
-
+/**
+ * Convert a mintr endpoint's JSON result to a Spring ResponseEntity.
+ */
+fun Response.jsonAsResponseEntity(): ResponseEntity<String> {
     if (this.statusCode == -1) {
-        return ErrorDetail(httpStatus, "No response returned. The request may have timed out.")
-            .toResponseEntity() as ResponseEntity<String>
+        return ErrorDetail(HttpStatus.SERVICE_UNAVAILABLE, "No response returned. The request may have timed out.")
+            .toResponseEntity()
     }
 
+    val httpStatus = httpStatusFromCode(this.statusCode)
     return try {
         val body = this.body().asString("application/json")
         val json = ObjectMapper().readTree(body)
@@ -27,9 +28,32 @@ fun Response.asResponseEntity(): ResponseEntity<String> {
         ResponseEntity.status(httpStatus)
             .contentType(MediaType.APPLICATION_JSON)
             .body(body)
-    } catch (e: IOException) {
-        ErrorDetail(httpStatus, "Could not parse response.")
-            .toResponseEntity() as ResponseEntity<String>
+    } catch (@Suppress("SwallowedException") e: IOException) {
+        ErrorDetail(HttpStatus.INTERNAL_SERVER_ERROR, "Could not parse response.")
+            .toResponseEntity()
+    }
+}
+
+/**
+ * Convert a mintr endpoint's binary result to a Spring ResponseEntity.
+ *
+ * This assumes the endpoint returns a binary result for successful HTTP error
+ * codes but a JSON object on error.
+ */
+fun Response.binaryAsResponseEntity(): ResponseEntity<out Any> {
+    if (this.statusCode == -1) {
+        return ErrorDetail(HttpStatus.SERVICE_UNAVAILABLE, "No response returned. The request may have timed out.")
+            .toResponseEntity()
+    }
+
+    val httpStatus = httpStatusFromCode(this.statusCode)
+    return if (httpStatus.is2xxSuccessful()) {
+        val body = this.body().toByteArray()
+        ResponseEntity.status(httpStatus)
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(body)
+    } else {
+        this.jsonAsResponseEntity()
     }
 }
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/CostController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/CostController.kt
@@ -8,25 +8,21 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/cost")
 class CostController(private val apiClient: APIClient) {
     @GetMapping("/graph/cases-averted/config")
-    @ResponseBody
     fun graphCasesAvertedConfig(): ResponseEntity<String> {
         return apiClient.getCostCasesAvertedGraphConfig()
     }
 
     @GetMapping("/graph/per-case/config")
-    @ResponseBody
     fun graphCostPerCaseConfig(): ResponseEntity<String> {
         return apiClient.getCostPerCaseGraphConfig()
     }
 
     @GetMapping("/table/config")
-    @ResponseBody
     fun tableConfig(): ResponseEntity<String> {
         return apiClient.getCostTableConfig()
     }
 
     @GetMapping("/docs")
-    @ResponseBody
     fun docs(): ResponseEntity<String> {
         return apiClient.getCostDocs()
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/EmulatorController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/EmulatorController.kt
@@ -1,0 +1,20 @@
+package org.imperial.mrc.mint.controllers
+
+import org.imperial.mrc.mint.APIClient
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/emulator")
+class EmulatorController(private val apiClient: APIClient) {
+
+    @GetMapping("/config")
+    fun emulatorConfig(): ResponseEntity<String> {
+        return apiClient.getEmulatorConfig()
+    }
+
+    @GetMapping("/model/{filename:.+}")
+    fun emulatorModel(@PathVariable filename: String): ResponseEntity<out Any> {
+        return apiClient.getEmulatorModel(filename)
+    }
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/HomeController.kt
@@ -9,7 +9,6 @@ import org.springframework.ui.set
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.ResponseBody
 
 @Controller
 class HomeController(
@@ -24,13 +23,11 @@ class HomeController(
     }
 
     @PostMapping("/table/data")
-    @ResponseBody
     fun tableData(@RequestBody dataOptions: Map<String, Any>): ResponseEntity<String> {
         return apiClient.getTableData(dataOptions)
     }
 
     @GetMapping("/version")
-    @ResponseBody
     fun version(): ResponseEntity<String> {
         return apiClient.getVersion()
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/ImpactController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/ImpactController.kt
@@ -9,31 +9,26 @@ import org.springframework.web.bind.annotation.*
 class ImpactController(private val apiClient: APIClient) {
 
     @GetMapping("/graph/prevalence/config")
-    @ResponseBody
     fun graphPrevalenceConfig(): ResponseEntity<String> {
         return apiClient.getImpactGraphPrevalenceConfig()
     }
 
     @GetMapping("/graph/cases-averted/config")
-    @ResponseBody
     fun graphCasesAvertedConfig(): ResponseEntity<String> {
         return apiClient.getImpactGraphCasesAvertedConfig()
     }
 
     @PostMapping("/graph/prevalence/data")
-    @ResponseBody
     fun graphPrevalenceData(@RequestBody dataOptions: Map<String, Any>): ResponseEntity<String> {
         return apiClient.getImpactGraphPrevalenceData(dataOptions)
     }
 
     @GetMapping("/table/config")
-    @ResponseBody
     fun tableConfig(): ResponseEntity<String> {
         return apiClient.getImpactTableConfig()
     }
 
     @GetMapping("/docs")
-    @ResponseBody
     fun docs(): ResponseEntity<String> {
         return apiClient.getImpactDocs()
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/OptionsController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/OptionsController.kt
@@ -9,13 +9,11 @@ import org.springframework.web.bind.annotation.*
 class OptionsController(private val apiClient: APIClient) {
 
     @GetMapping("/baseline/options")
-    @ResponseBody
     fun baselineOptions(): ResponseEntity<String> {
         return apiClient.getBaselineOptions()
     }
 
     @GetMapping("/intervention/options")
-    @ResponseBody
     fun interventionOptions(): ResponseEntity<String> {
         return apiClient.getInterventionOptions()
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/StrategiseController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/controllers/StrategiseController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*
 class StrategiseController(private val apiClient: APIClient) {
 
     @PostMapping("/strategise")
-    @ResponseBody
     fun strategise(@RequestBody options: Map<String, Any>): ResponseEntity<String> {
         return apiClient.getStrategies(options)
     }

--- a/src/app/src/main/kotlin/org/imperial/mrc/mint/models/ErrorDetail.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/mint/models/ErrorDetail.kt
@@ -11,8 +11,8 @@ class ErrorDetail(
 ) {
 
     val error = "OTHER_ERROR"
-    fun toResponseEntity(): ResponseEntity<Any> = ResponseEntity
+    fun toResponseEntity(): ResponseEntity<String> = ResponseEntity
         .status(this.httpStatus)
         .contentType(MediaType.APPLICATION_JSON)
-        .body(ErrorResponse(listOf(this)).toJsonString() as Any)
+        .body(ErrorResponse(listOf(this)).toJsonString())
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EmulatorTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EmulatorTests.kt
@@ -1,0 +1,29 @@
+package org.imperial.mrc.mint.integration.endpoints
+
+import org.assertj.core.api.Assertions.assertThat
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.web.client.getForEntity
+
+class EmulatorTests: EndpointTests() {
+    @Test
+    fun `can get emulator config`() {
+        val responseEntity = testRestTemplate.getForEntity<String>("/emulator/config")
+        assertSuccessfulValidJson(responseEntity, "EmulatorOptions")
+
+        val response = ObjectMapper().readTree(responseEntity.body)
+        assertThat(response["data"]["models"]).isNotEmpty()
+    }
+
+    @Test
+    fun `can get emulator data`() {
+        val responseEntity = testRestTemplate.getForEntity<String>("/emulator/config")
+        val response = ObjectMapper().readTree(responseEntity.body)
+        val modelConfig = response["data"]["models"].first()
+        val modelFilename = modelConfig["filename"].textValue()
+
+        val modelEntity = testRestTemplate.getForEntity<ByteArray>("/emulator/model/${modelFilename}")
+        assertSuccess(modelEntity)
+        assertThat(modelEntity.headers.contentType!!.toString()).isEqualTo("application/octet-stream")
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EndpointTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/integration/endpoints/EndpointTests.kt
@@ -15,7 +15,7 @@ abstract class EndpointTests {
     @Autowired
     lateinit var testRestTemplate: TestRestTemplate
 
-    protected fun assertSuccess(responseEntity: ResponseEntity<String>) {
+    protected fun assertSuccess(responseEntity: ResponseEntity<*>) {
         if (responseEntity.statusCode != HttpStatus.OK) {
             Assertions.fail<String>("Expected OK response but got error: ${responseEntity.body}")
         }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/AppPropertiesTest.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/AppPropertiesTest.kt
@@ -1,6 +1,6 @@
 package org.imperial.mrc.mint.unit
 
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.mint.ConfiguredAppProperties
 import org.imperial.mrc.mint.MintProperties
 import org.junit.jupiter.api.AfterEach

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/ExtensionTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/ExtensionTests.kt
@@ -6,44 +6,48 @@ import com.github.kittinunf.fuel.core.*
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.assertj.core.api.Java6Assertions.assertThat
-import org.imperial.mrc.mint.asResponseEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.mint.jsonAsResponseEntity
+import org.imperial.mrc.mint.binaryAsResponseEntity
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import java.net.URL
 
 class ExtensionTests {
     @Test
     fun `response status code gets translated to HttpStatus`() {
+        val mockBody = mock<Body> {
+            on {it.asString(any())} doReturn "{\"status\": \"whatever\"}"
+        }
 
-        var res = Response(URL("http://whatever"), 200)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.OK)
+        var res = Response(URL("http://whatever"), 200, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.OK)
 
-        res = Response(URL("http://whatever"), 201)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.CREATED)
+        res = Response(URL("http://whatever"), 201, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.CREATED)
 
-        res = Response(URL("http://whatever"), 400)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        res = Response(URL("http://whatever"), 400, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
 
-        res = Response(URL("http://whatever"), 401)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        res = Response(URL("http://whatever"), 401, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
 
-        res = Response(URL("http://whatever"), 403)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        res = Response(URL("http://whatever"), 403, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.FORBIDDEN)
 
-        res = Response(URL("http://whatever"), 404)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        res = Response(URL("http://whatever"), 404, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.NOT_FOUND)
 
-        res = Response(URL("http://whatever"), 500)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-
+        res = Response(URL("http://whatever"), 500, body=mockBody)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
     }
 
     @Test
     fun `message is returned when status code is missing`() {
         val res = Response(URL("http://whatever"), -1)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-        val body = ObjectMapper().readTree(res.asResponseEntity().body)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        val body = ObjectMapper().readTree(res.jsonAsResponseEntity().body)
         val errorDetail = body["errors"].first()["detail"].textValue()
         assertThat(errorDetail).isEqualTo("No response returned. The request may have timed out.")
     }
@@ -54,8 +58,8 @@ class ExtensionTests {
             on {it.asString(any())} doReturn "Bad response"
         }
         val res = Response(URL("http://whatever"), 500, body = mockBody)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-        val body = ObjectMapper().readTree(res.asResponseEntity().body)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val body = ObjectMapper().readTree(res.jsonAsResponseEntity().body)
         val errorDetail = body["errors"].first()["detail"].textValue()
         assertThat(errorDetail).isEqualTo("Could not parse response.")
     }
@@ -66,10 +70,38 @@ class ExtensionTests {
             on {it.asString(any())} doReturn "{\"wrong\": \"schema\"}"
         }
         val res = Response(URL("http://whatever"), 500, body = mockBody)
-        assertThat(res.asResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-        val body = ObjectMapper().readTree(res.asResponseEntity().body)
+        assertThat(res.jsonAsResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val body = ObjectMapper().readTree(res.jsonAsResponseEntity().body)
         val errorDetail = body["errors"].first()["detail"].textValue()
         assertThat(errorDetail).isEqualTo("Could not parse response.")
     }
 
+    @Test
+    fun `binary payload is returned on success`() {
+        val mockBody = mock<Body> {
+            on {it.toByteArray()} doReturn byteArrayOf(1, 2, 3, 4)
+        }
+
+        val res = Response(URL("http://whatever"), 200, body=mockBody)
+        val entity = res.binaryAsResponseEntity()
+
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM)
+        assertThat(entity.body).isEqualTo(byteArrayOf(1, 2, 3, 4));
+    }
+
+    @Test
+    fun `binary endpoint returns JSON on error`() {
+        val mockBody = mock<Body> {
+            on {it.asString(any())} doReturn "{\"status\": \"error\"}"
+        }
+
+        val res = Response(URL("http://whatever"), 400, body=mockBody)
+        val entity = res.binaryAsResponseEntity()
+
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON)
+        val body = ObjectMapper().readTree(entity.body as? String);
+        assertThat(body["status"].textValue()).isEqualTo("error");
+    }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/EmulatorControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/mint/unit/controllers/EmulatorControllerTests.kt
@@ -1,0 +1,34 @@
+package org.imperial.mrc.mint.unit.controllers
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.any
+import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.mint.APIClient
+import org.imperial.mrc.mint.controllers.EmulatorController
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+
+class EmulatorControllerTests {
+    @Test
+    fun `gets emulator config from the api`() {
+        val mockResponse = mock<ResponseEntity<String>>()
+        val mockAPI = mock<APIClient> {
+            on { getEmulatorConfig() } doReturn mockResponse
+        }
+
+        val sut = EmulatorController(mockAPI)
+        assertThat(sut.emulatorConfig()).isSameAs(mockResponse)
+    }
+
+    @Test
+    fun `gets emulator data from the api`() {
+        val mockResponse = mock<ResponseEntity<out Any>>()
+        val mockAPI = mock<APIClient> {
+            on { getEmulatorModel("foobar") } doReturn mockResponse
+        }
+
+        val sut = EmulatorController(mockAPI)
+        assertThat(sut.emulatorModel("foobar")).isSameAs(mockResponse)
+    }
+}

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -66,6 +66,8 @@ subprojects {
     }
 
     group = 'org.imperial.mrc'
-    sourceCompatibility = '1.8'
 
+    java {
+        sourceCompatibility = '1.8'
+    }
 }

--- a/testdata/emulator/README.md
+++ b/testdata/emulator/README.md
@@ -1,0 +1,5 @@
+This directory contains a dummy version of the MINT emulator, for use in
+integration testing of MINT.
+
+Eventually, once a stable pipeline for the emulator exists and is embedded into
+mintr we may be able to switch the integration tests to using that.

--- a/testdata/emulator/config.json
+++ b/testdata/emulator/config.json
@@ -1,0 +1,8 @@
+{
+  "models": [
+    {
+      "name": "FFNN",
+      "filename": "FFNN.onnx"
+    }
+  ]
+}


### PR DESCRIPTION
This adds two new endpoints, `/emulator/config` and `/emulator/model/...`, as direct proxies for the equivalent mintr endpoints.